### PR TITLE
[accessibility] Add text alternatives for images & accessible names to links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,7 @@
     <meta property="og:image" content="{{ "/img/share-image.png" | absolute_url }}">
     <meta property="og:image:width" content="1024">
     <meta property="og:image:height" content="512">
+    <meta property="og:image:alt" content="MapLibre">
     <meta property="og:title" content="{{ page.title }}">
     <meta property="og:description" content="{{ page.description }}">
     <meta property="og:url" content="{{ page.url }}">
@@ -22,6 +23,7 @@
     <meta name="twitter:title" content="{{ page.title }}">
     <meta name="twitter:description" content="{{ page.description }}">
     <meta name="twitter:image:src" content="{{ "/img/share-image.png" | absolute_url }}">
+    <meta name="twitter:image:alt" content="MapLibre">
 
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Alata&display=swap" rel="stylesheet">
@@ -53,26 +55,26 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     
   <nav class="navbar navbar-expand-lg navbar-dark fixed-top {% if page.fullscreen != true %}bg-navbar{% else %}bg-fullscreen{% endif %} ">
     <div class="container">
-      <a class="navbar-brand" href="{{ "/" | relative_url }}">
-        <svg width="141" height="30" viewBox="0 0 141 30" xmlns="http://www.w3.org/2000/svg"><use href="{{ "/" | relative_url }}img/maplibre-logo.svg#maplibre-logo"></use></svg>
+      <a class="navbar-brand" href="{{ "/" | relative_url }}" aria-label="MapLibre">
+        <svg aria-hidden="true" width="141" height="30" viewBox="0 0 141 30" xmlns="http://www.w3.org/2000/svg"><use href="{{ "/" | relative_url }}img/maplibre-logo.svg#maplibre-logo"></use></svg>
       </a>
       <div class="d-flex">
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
-        <a class="nav-link py-1 py-lg-0 d-flex align-items-center d-lg-none text-white" href="https://github.com/MapLibre">
-          <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 30 30"><use href="{{ "/" | relative_url }}img/github.svg#github"></use></svg>
+        <a class="nav-link py-1 py-lg-0 d-flex align-items-center d-lg-none text-white" href="https://github.com/MapLibre" aria-label="MapLibre organization on Github">
+          <svg aria-hidden="true" version="1.1" xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 30 30"><use href="{{ "/" | relative_url }}img/github.svg#github"></use></svg>
         </a>
       </div>
       <div class="collapse navbar-collapse justify-content-end" id="navbarNavAltMarkup">
         <div class="navbar-nav">
           <a class="nav-link" href="{{ "/" | relative_url }}about/">About</a>
           <a class="nav-link" href="{{ "/" | relative_url }}projects/">Projects</a>
-          <a class="nav-link" href="https://github.com/sponsors/maplibre">♡ Sponsor</a>
+          <a class="nav-link" href="https://github.com/sponsors/maplibre"><span aria-hidden="true">♡</span> Sponsor</a>
         </div>
       </div>
-      <a class="nav-link py-1 py-lg-0 d-none align-items-center d-lg-flex text-white" href="https://github.com/MapLibre">
-        <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 30 30"><use href="{{ "/" | relative_url }}img/github.svg#github"></use></svg>
+      <a class="nav-link py-1 py-lg-0 d-none align-items-center d-lg-flex text-white" href="https://github.com/MapLibre" aria-label="MapLibre organization on Github">
+        <svg aria-hidden="true" version="1.1" xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 30 30"><use href="{{ "/" | relative_url }}img/github.svg#github"></use></svg>
       </a>
     </div>
   </nav>
@@ -80,8 +82,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
    {% if page.fullscreen != true %}
    <footer class="mt-auto">
      <div class="container pb-4 pt-6">
-       <a href="{{ "/" | relative_url }}">
-         <svg width="141" height="30" viewBox="0 0 141 30" xmlns="http://www.w3.org/2000/svg"><use href="{{ "/" | relative_url }}img/maplibre-logo-dark.svg#maplibre"></use></svg>
+       <a href="{{ "/" | relative_url }}" aria-label="MapLibre">
+         <svg aria-hidden="true" width="141" height="30" viewBox="0 0 141 30" xmlns="http://www.w3.org/2000/svg"><use href="{{ "/" | relative_url }}img/maplibre-logo-dark.svg#maplibre"></use></svg>
        </a>
      </div>
      <div class="container border-top border-gray">
@@ -95,20 +97,20 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
          </div>
          <div class="col-sm-6">
            <div class="nav justify-content-end">
-             <a class="nav-link text-black-50" href="#">
-               <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><use href="{{ "/" | relative_url }}img/icon/fb.svg#fb"></use></svg>
+             <a class="nav-link text-black-50" href="#" aria-label="MapLibre on Facebook">
+               <svg aria-hidden="true" version="1.1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><use href="{{ "/" | relative_url }}img/icon/fb.svg#fb"></use></svg>
              </a>
-             <a class="nav-link text-black-50" href="#">
-               <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><use href="{{ "/" | relative_url }}img/icon/linkedin.svg#linkedin"></use></svg>
+             <a class="nav-link text-black-50" href="#" aria-label="MapLibre on LinkedIn">
+               <svg aria-hidden="true" version="1.1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><use href="{{ "/" | relative_url }}img/icon/linkedin.svg#linkedin"></use></svg>
              </a>
-             <a class="nav-link text-black-50" href="#">
-               <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><use href="{{ "/" | relative_url }}img/icon/twt.svg#twt"></use></svg>
+             <a class="nav-link text-black-50" href="#" aria-label="MapLibre on Twitter">
+               <svg aria-hidden="true" version="1.1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><use href="{{ "/" | relative_url }}img/icon/twt.svg#twt"></use></svg>
              </a>
-             <a class="nav-link text-black-50" href="#">
-               <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><use href="{{ "/" | relative_url }}img/icon/ytb.svg#ytb"></use></svg>
+             <a class="nav-link text-black-50" href="#" aria-label="MapLibre on YouTube">
+               <svg aria-hidden="true" version="1.1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><use href="{{ "/" | relative_url }}img/icon/ytb.svg#ytb"></use></svg>
              </a>
-             <a class="nav-link text-black-50" href="#">
-               <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><use href="{{ "/" | relative_url }}img/icon/ig.svg#ig"></use></svg>
+             <a class="nav-link text-black-50" href="#" aria-label="MapLibre on Instagram">
+               <svg aria-hidden="true" version="1.1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><use href="{{ "/" | relative_url }}img/icon/ig.svg#ig"></use></svg>
              </a>
            </div>
          </div>

--- a/src/index.html
+++ b/src/index.html
@@ -17,8 +17,8 @@ sitemap:
       <div class="col-lg-4">
         <h1 class="h2 mt-2 mt-lg-0">Open Maps SDKs</h1>
         <p>Open-source mapping libraries for developers of web and mobile applications.</p>
-        <a class="btn btn-primary mt-1" href="https://github.com/maplibre/maplibre-gl-js" role="button">Javascript</a>
-        <a class="btn btn-primary mt-1" href="https://github.com/maplibre/maplibre-gl-native" role="button">Android / iOS</a>
+        <a class="btn btn-primary mt-1" href="https://github.com/maplibre/maplibre-gl-js">Javascript</a>
+        <a class="btn btn-primary mt-1" href="https://github.com/maplibre/maplibre-gl-native">Android / iOS</a>
       </div>
     </div>
 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -12,7 +12,7 @@ sitemap:
 <div class="home-banner">
     <div class="row align-items-center p-5">
       <div class="col-lg-8 text-lg-center">
-        <svg class="title-image" width="353" height="76" viewBox="0 0 353 76" xmlns="http://www.w3.org/2000/svg"><use href="{{ "/" | relative_url }}img/maplibre-logo-big.svg#maplibre"></use></svg>
+        <svg aria-label="MapLibre" class="title-image" width="353" height="76" viewBox="0 0 353 76" xmlns="http://www.w3.org/2000/svg"><use href="{{ "/" | relative_url }}img/maplibre-logo-big.svg#maplibre"></use></svg>
       </div>
       <div class="col-lg-4">
         <h1 class="h2 mt-2 mt-lg-0">Open Maps SDKs</h1>


### PR DESCRIPTION
Many links and images are only conveyed to visual users.

This PR:
- [x] Adds [text alternatives](https://www.w3.org/TR/WCAG21/#text-alternatives) ([accessible names](https://www.w3.org/TR/accname-1.1/#dfn-accessible-name)) to images using [`aria-label`](https://www.w3.org/TR/wai-aria/#aria-label), [`og:image:alt`](https://ogp.me/#:~:text=og:image:alt) and [`twitter:image:alt`](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup#:~:text=twitter:image:alt).
  (In the case of for example SVGs, `<title>` _could_ provide the accessible name, but that would display a tooltip on hover (looks similar to that of the `title` attribute) which I didn't want to impose so I went with `aria-label` instead.)
- [x] Provides links with accessible names using `aria-label` (and hides the child SVG elements using [`aria-hidden="true"`](https://www.w3.org/TR/wai-aria/#aria-hidden) as their [roles](https://www.w3.org/TR/accname-1.1/#dfn-role) may be exposed which is redundant in these cases).
- [x] Removes [`role="button"`](https://www.w3.org/TR/wai-aria/#button) from 2 links. These links behave like links and should not have their implicit [link](https://www.w3.org/TR/wai-aria/#link) role overriden.