### PR TITLE
Make it more clear that MapTiler has an example implementation of MapLibre

### DIFF
--- a/src/projects.html
+++ b/src/projects.html
@@ -20,21 +20,23 @@ sitemap:
       <p>Open-source JavaScript library for publishing maps on your websites.</p>
       <p>Fast displaying of maps is possible thanks to GPU-accelerated vector tile rendering.</p>
       <p>Originated as an open-source fork of <i>mapbox-gl-js</i>, the library is intended to be a drop-in replacement for the Mapbox’s version with additional functionality.</p>
-      <p>Read documentation:
+      <p>See documentation: <a href="https://maplibre.org/maplibre-gl-js-docs">maplibre.org/maplibre-gl-js-docs</a>
+      <p>Third party integrations:
         <ul>
-          <li><a href="https://maplibre.org/maplibre-gl-js-docs">maplibre.org/maplibre-gl-js-docs</a></li>
-          <li><a href="https://docs.maptiler.com/maplibre-gl-js">docs.maptiler.com/maplibre-gl-js</a></li>
+          <li>MapTiler <a href="https://docs.maptiler.com/maplibre-gl-js">docs.maptiler.com/maplibre-gl-js</a></li>
         </ul>
       </p>
+      
 
       <h2 class="mt-6" id="native">MapLibre Native</h2>
       <p>Open-source SDK for Android and iOS allowing displaying maps inside of your mobile applications, desktop application, or embedded devices.</p>
       <p>This toolset grants fast maps displaying in iOS and Android apps using the same GPU-based acceleration as the JavaScript version.</p>
       <p><i>MapLibre-Native</i> is an open source fork of <i>mapbox-native</i> with additional functionality.</p>
-      <p>Read documentation:
+      <p>View on GitHub: <a href="https://github.com/maplibre/maplibre-gl-native">github.com/maplibre/maplibre-gl-native</a></li>
+      <p>Third party integrations:
         <ul>
-          <li>Android - <a href="https://docs.maptiler.com/maplibre-gl-native-android">docs.maptiler.com/maplibre-gl-native-android</a></li>
-          <li>iOS - <a href="https://docs.maptiler.com/maplibre-gl-native-ios">docs.maptiler.com/maplibre-gl-native-ios</a></li>
+          <li>MapTiler Android <a href="https://docs.maptiler.com/maplibre-gl-native-android">docs.maptiler.com/maplibre-gl-native-android</a></li>
+          <li>MapTiler iOS <a href="https://docs.maptiler.com/maplibre-gl-native-ios">docs.maptiler.com/maplibre-gl-native-ios</a></li>
         </ul>
       </p>
 


### PR DESCRIPTION
Make it more clear to the user that MapTiler can be used as an example how to integrate MapLibre products and repo's.