### PR TITLE
Add link to community map

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -71,6 +71,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           <a class="nav-link" href="{{ "/" | relative_url }}about/">About</a>
           <a class="nav-link" href="{{ "/" | relative_url }}news/">News</a>
           <a class="nav-link" href="{{ "/" | relative_url }}projects/">Projects</a>
+          <a class="nav-link" href="{{ "/" | relative_url }}community/">Community</a>
           <a class="nav-link" href="https://github.com/sponsors/maplibre"><span aria-hidden="true">♡</span> Sponsor</a>
         </div>
       </div>


### PR DESCRIPTION
Adds a link in the navbar to https://maplibre.org/community/﻿
