### PR TITLE
Fix link to maplibre-gl-js

### DIFF
--- a/content/projects/maplibre-gl-js/index.md
+++ b/content/projects/maplibre-gl-js/index.md
@@ -1,7 +1,7 @@
 ---
 title: "MapLibre GL JS"
 weight: -1000
-github: https://github.com/maplibre/maplibre-gl-native
+github: https://github.com/maplibre/maplibre-gl-js
 documentation:
   - url: https://maplibre.org/maplibre-gl-js-docs
     name: "API Documentation"


### PR DESCRIPTION
Updates the link from maplibre-gl-native to maplibre-gl-js