### PR TITLE
Emphasize that maplibre-gl-js is written in TS

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -33,10 +33,10 @@ weight: -10
       <h1 class="h2 mt-2 mt-lg-0">Open Maps SDKs</h1>
       <p>Open-source mapping libraries for web and mobile app developers.</p>
       <a class="btn btn-primary mt-1" href="/projects/maplibre-gl-js"
-        >JavaScript</a
+        >TypeScript for Web</a
       >
       <a class="btn btn-primary mt-1" href="/projects/maplibre-native"
-        >Android / iOS</a
+        >C++ for Android & iOS</a
       >
     </div>
   </div>

--- a/content/projects/maplibre-gl-js/index.md
+++ b/content/projects/maplibre-gl-js/index.md
@@ -8,7 +8,7 @@ documentation:
 stable: true
 ---
 
-Open-source JavaScript library for publishing maps on your websites.
+Open-source TypeScript library for publishing maps on your websites.
 Fast displaying of maps is possible thanks to GPU-accelerated vector tile rendering.
 
 Originated as an open-source fork of _mapbox-gl-js_, the library is

--- a/content/projects/maplibre-native/index.md
+++ b/content/projects/maplibre-native/index.md
@@ -13,7 +13,7 @@ stable: true
 Open-source SDK for Android and iOS allowing displaying maps inside of your
 mobile applications, desktop application, or embedded devices.
 This toolset grants fast maps displaying in iOS and Android apps using the
-same GPU-based acceleration as the JavaScript version.
+same GPU-based acceleration as the TypeScript version.
 
 _MapLibre-Native_ is an open source fork of _mapbox-native_ with
 additional functionality.


### PR DESCRIPTION
Since finalising the transition from JS to TS, we should update our communication to reflect that.