### PR TITLE
Align about page to charter

### DIFF
--- a/content/about.html
+++ b/content/about.html
@@ -7,19 +7,21 @@ weight: 10
 <div class="col-sm-8">
   <h2>About</h2>
   <p>
-    MapLibre is a community-governed collection of open source mapping
-    libraries. As a community, we believe in building and maintaining freely
-    licensed libraries that enable developers worldwide to build vital tools
-    using maps.
+
+    MapLibre is a community-governed non-profit organization that develop, maintain and promote
+    free open-source software. Each project under the MapLibre umbrella is part of the map
+    visualization stack from the raw data to the map visualization and interaction.
   </p>
   <p>
-    Motivated by the 2020 transition to proprietary licensing for
-    Mapbox&nbsp;GL&nbsp;JS, the initial libraries are forks of the
-    Mapbox&nbsp;GL ecosystem—for the web and mobile platforms.
+    MapLibre started as an open-source fork of the popular Mapbox rendering libraries after their
+    switch to a proprietary license in December 2020. Often "MapLibre" still refers to these key
+    rendering libraries: MapLibre GL JS which is a TypeScript framework for rendering maps in web browsers,
+    and MapLibre GL Native which is a C++ library to show maps in mobile apps on iOS, Android and
+    other native targets.
   </p>
   <p>
-    Our goal is to continue building on the foundation of Mapbox’s original
-    open-source code under the BSD license without tracking end-users.
+    As a community, we believe in building and maintaining freely licensed libraries that enable
+    developers worldwide to build vital tools using maps.
   </p>
 
   <h2 class="mt-6">Organization</h2>

--- a/content/about.html
+++ b/content/about.html
@@ -7,16 +7,15 @@ weight: 10
 <div class="col-sm-8">
   <h2>About</h2>
   <p>
-
-    MapLibre is a community-governed non-profit organization that develop, maintain and promote
-    free open-source software. Each project under the MapLibre umbrella is part of the map
-    visualization stack from the raw data to the map visualization and interaction.
+    MapLibre is a community-governed non-profit organization that develops, maintains, and promotes
+    free, open-source software. Each project under the MapLibre umbrella is part of the map
+    visualization stack, from the raw data to the map visualization and interaction.
   </p>
   <p>
     MapLibre started as an open-source fork of the popular Mapbox rendering libraries after their
     switch to a proprietary license in December 2020. Often "MapLibre" still refers to these key
-    rendering libraries: MapLibre GL JS which is a TypeScript library for rendering maps in web browsers,
-    and MapLibre GL Native which is a C++ library to show maps in mobile apps on iOS, Android and
+    rendering libraries: MapLibre GL JS, which is a TypeScript library for rendering maps in web browsers,
+    and MapLibre GL Native, which is a C++ library to show maps in mobile apps on iOS, Android, and
     other native targets.
   </p>
   <p>

--- a/content/about.html
+++ b/content/about.html
@@ -15,7 +15,7 @@ weight: 10
   <p>
     MapLibre started as an open-source fork of the popular Mapbox rendering libraries after their
     switch to a proprietary license in December 2020. Often "MapLibre" still refers to these key
-    rendering libraries: MapLibre GL JS which is a TypeScript framework for rendering maps in web browsers,
+    rendering libraries: MapLibre GL JS which is a TypeScript library for rendering maps in web browsers,
     and MapLibre GL Native which is a C++ library to show maps in mobile apps on iOS, Android and
     other native targets.
   </p>

--- a/content/about.html
+++ b/content/about.html
@@ -7,20 +7,22 @@ weight: 10
 <div class="col-sm-8">
   <h2>About</h2>
   <p>
-    MapLibre is a community-governed non-profit organization that develops, maintains, and promotes
-    free, open-source software. Each project under the MapLibre umbrella is part of the map
-    visualization stack, from the raw data to the map visualization and interaction.
+    MapLibre is a community-governed non-profit organization that develops,
+    maintains, and promotes free, open-source software. Each project under the
+    MapLibre umbrella is part of the map visualization stack, from the raw data
+    to the map visualization and interaction.
   </p>
   <p>
-    MapLibre started as an open-source fork of the popular Mapbox rendering libraries after their
-    switch to a proprietary license in December 2020. Often "MapLibre" still refers to these key
-    rendering libraries: MapLibre GL JS, which is a TypeScript library for rendering maps in web browsers,
-    and MapLibre GL Native, which is a C++ library to show maps in mobile apps on iOS, Android, and
-    other native targets.
+    MapLibre started as an open-source fork of the popular Mapbox rendering
+    libraries after their switch to a proprietary license in December 2020.
+    Often "MapLibre" still refers to these key rendering libraries: MapLibre GL
+    JS, which is a TypeScript library for rendering maps in web browsers, and
+    MapLibre GL Native, which is a C++ library to show maps in mobile apps on
+    iOS, Android, and other native targets.
   </p>
   <p>
-    As a community, we believe in building and maintaining freely licensed libraries that enable
-    developers worldwide to build vital tools using maps.
+    As a community, we believe in building and maintaining freely licensed
+    libraries that enable developers worldwide to build vital tools using maps.
   </p>
 
   <h2 class="mt-6">Organization</h2>


### PR DESCRIPTION
Aligning the about page to our https://github.com/maplibre/maplibre/blob/main/CHARTER.md