### PR TITLE
Add MIERUNE textual link

### DIFF
--- a/content/sponsors.html
+++ b/content/sponsors.html
@@ -29,6 +29,13 @@ weight: 10
     <img src="/img/meta-logo.svg" />
   </p>
 
+  <p>
+    <b>Stone Tier:</b>
+    <br />
+    <br />
+    <a href="https://www.mierune.co.jp/?lang=en">MIERUNE Inc.</a>
+  </p>
+
   <h2 class="mt-6">MapLibre Sponsorship Program</h2>
   <p>
     The MapLibre Sponsorship Program aims to secure the continuity of the


### PR DESCRIPTION
Add a textual link to MIERUNE Inc. since they are sponsoring us at the newly created Stone tier.

https://github.com/maplibre/maplibre/issues/110