### PR TITLE
Add jobs.html

### DIFF
--- a/content/jobs.html
+++ b/content/jobs.html
@@ -1,0 +1,24 @@
+---
+title: Jobs
+menu: [main, footer]
+weight: 10
+---
+
+<div class="col-sm-8">
+  <h2>Jobs</h2>
+  <p>Description</p>
+
+  <h3>Apply Now</h3>
+  <script
+    charset="utf-8"
+    type="text/javascript"
+    src="//js-eu1.hsforms.net/forms/embed/v2.js"
+  ></script>
+  <script>
+    hbspt.forms.create({
+      region: "eu1",
+      portalId: "26270291",
+      formId: "17cab110-3762-4bcf-88c3-7f7fc7975099",
+    });
+  </script>
+</div>


### PR DESCRIPTION
Adds a "Jobs" tab with some description about the paid roles and the HubSpot application form.

![image](https://user-images.githubusercontent.com/53421382/194147748-f4f7db38-8469-45f6-82ea-e90795e7989d.png)

![image](https://user-images.githubusercontent.com/53421382/194147813-798d3ddb-5983-459c-94ca-1507ae9db352.png)

The stand-alone application form is available here: https://share-eu1.hsforms.com/1F8qxEDdiS8-Iw39_x5dQmQfn2ab and I think it looks nicer if it is embedded in our website.

I need to write something in the description and link to the wiki...