### PR TITLE
Add community members

### DIFF
--- a/data/community.json
+++ b/data/community.json
@@ -358,5 +358,73 @@
   {
     "github": "HackJack-101",
     "latlon": [44.8269238, -0.6019734]
+  },
+  {
+    "github": "rotu",
+    "latlon": [44.9467641, -93.3083466]
+  },
+  {
+    "github": "zhangyiatmicrosoft",
+    "latlon": [47.5520613, -122.1153242]
+  },
+  {
+    "github": "VehpuS",
+    "latlon": [31.5119203, 34.7415089]
+  },
+  {
+    "github": "moshe-gr-albo",
+    "latlon": [32.0694326, 34.7767776]
+  },
+  {
+    "github": "zavalit",
+    "latlon": [52.5386381, 13.2448602]
+  },
+  {
+    "github": "pgoldberg",
+    "latlon": [38.8896867, -77.08943]
+  },
+  {
+    "github": "gzurbach",
+    "latlon": [45.7419439, 4.8474977]
+  },
+  {
+    "github": "cndv3996",
+    "latlon": [47.6331731, -122.1230166]
+  },
+  {
+    "github": "guimochila",
+    "latlon": [52.8627198, 6.2292417]
+  },
+  {
+    "github": "blymemikkel",
+    "latlon": [55.6793621, 12.5529445]
+  },
+  {
+    "github": "caspg",
+    "latlon": [51.6084498, 21.3886359]
+  },
+  {
+    "github": "gregsadetsky",
+    "latlon": [40.5371052, -74.1518587]
+  },
+  {
+    "github": "artakka",
+    "latlon": [47.6440267, -121.907117]
+  },
+  {
+    "github": "sjg-wdw",
+    "latlon": [37.7413288, -122.4310928]
+  },
+  {
+    "github": "alanchenboy",
+    "latlon": [39.9502877, 116.2053366]
+  },
+  {
+    "github": "carlonzo",
+    "latlon": [24.9681249, 55.0674521]
+  },
+  {
+    "github": "thehoneymad",
+    "latlon": [49.2772261, -123.044999]
   }
 ]


### PR DESCRIPTION
Adds people who contributed to MapLibre to the map at https://maplibre.org/community/

If you are in this list, it is because your GitHub handle appears in the public commit history of a repo in the MapLibre GitHub organization. Your location was taken from your public GitHub profile.

If you would like to be removed, let me know and I will delete your entry.

People included are: 

@zhangyiatmicrosoft, @VehpuS, @moshe-gr-albo, @zavalit, @pgoldberg, @gzurbach, @cndv3996, @guimochila, @blymemikkel, @caspg, @gregsadetsky, @artakka, @sjg-wdw, @alanchenboy, @carlonzo, @thehoneymad, 

