### PR TITLE
Announce Ovi starts as Maintainer

### DIFF
--- a/content/news/2023-01-16-announcement-ovi.md
+++ b/content/news/2023-01-16-announcement-ovi.md
@@ -1,0 +1,27 @@
+---
+title: "Ovidiu Voda starts as Maintainer Native"
+date: "2023-01-16"
+categories: ["announcements"]
+authors: [wipfli]
+---
+
+With Ovidiu Voda starting today, we are proud to now have two people working as Maintainers on MapLibre GL Native. Please give Ovi a warm welcome!
+
+Ovi is going to work together with Bart Louwers on Native and he is looking forward to meeting everyone involved in the project. Feel free to reach out to Ovi and say hi to him.
+
+<p>
+    <a href="https://github.com/ovivoda">
+        <img
+        src="https://avatars.githubusercontent.com/u/5989047?v=4"
+        width="200"
+        />
+    </a>
+</p>
+
+- LinkedIn: https://www.linkedin.com/in/oviv/
+- GitHub: https://github.com/ovivoda
+- Slack: `@Ovi` in the OSMUS Slack channel at https://slack.openstreetmap.us/
+
+We plan to initially work together with Ovi for three months, January, February, March 2023, and then evaluate how we best proceed.
+
+Ovi previously led Mapillary's Android team. It is a big honor for MapLibre to contract with a person who is as experienced as Ovi and we are looking forward to what the future will bring!


### PR DESCRIPTION
Adds a news article about Ovi starting as Maintainer Native.

Since we anyway announce all news articles on Twitter and LinkedIn for more visibility, I suggest that when we do a news article, we also already add the tweet text and we get 2 Board members approving it. Like that, when we merge the news article, we can directly put the link on twitter, linkedin.

Twitter text:

> With Ovidiu Voda starting today, we are proud to now have two people working as Maintainers on MapLibre GL Native. Please give Ovi a warm welcome!