### PR TITLE
Add announcement Harel starts as Maintainer Web

### DIFF
--- a/content/news/2023-01-16-announcement-harel.md
+++ b/content/news/2023-01-16-announcement-harel.md
@@ -1,0 +1,41 @@
+---
+title: "Harel Mazor starts as Maintainer Web"
+date: "2023-01-16"
+categories: ["announcements"]
+authors: [wipfli]
+---
+
+We are happy to share that we were able to contract Harel Mazor, the long-time lead-maintainer of MapLibre GL JS, for the Maintainer Web role. Please give him a warm welcome!
+
+<p>
+    <a href="https://github.com/HarelM/">
+        <img
+        src="https://avatars.githubusercontent.com/u/3269297?v=4"
+        width="200"
+        />
+    </a>
+</p>
+
+- LinkedIn: https://www.linkedin.com/in/harel-mazor-1298b139/
+- GitHub: https://github.com/HarelM/
+- Slack: `@Harel Mazor` in the OSMUS Slack channel at https://slack.openstreetmap.us/
+
+Harel started being involved in the development of GL JS by contributing the `addProtocol()` function (Pull Request https://github.com/maplibre/maplibre-gl-js/pull/30) function in 2021, and made a huge overhaul of the library by migrating it to TypeScript (Pull Request https://github.com/maplibre/maplibre-gl-js/pull/209). Harel became the most active maintainer of MapLibre GL JS and reviewed pull request after pull request, triaged issues, and helped users getting started.
+
+Out of all candidates for the Maintainer Web role, Harel was the best because of his technical strength, in-depth knowledge of the codebase, familiarity with the community, and dedication and commitment to the project.
+
+Harel covered the [requirements](https://github.com/maplibre/maplibre/wiki/Maintainer-Web-Role#requirements) of the Maintainer Web role for months and years as a volunteer and we are thankful for all his contributions. Since December 2022, the Governing Board has approved [budget](https://github.com/maplibre/maplibre/files/10114728/Budget.Dec.2022.Jan.2023.Feb.2023.-.budget.pdf) for the Maintainer Web role and we will acknowledge Harel's work as Maintainer in the time period Dec 1st, 2022 to Jan 15th, 2023 with a one-time flat payment.
+
+Harel will serve in the Maintainer Web role until March 31st, 2023 and then we will assess the situation and decide how to best proceed.
+
+## Conflict of Interest
+
+Being a member of the MapLibre Governing Board, Harel has a clear conflict of interest.
+
+We talked about this conflict early on and agreed that Harel would abstain from all discussions and decisions related to the Maintainer Web hiring and that he would be excluded from any communication around the hiring process.
+
+Regarding deciding on [budget allocation](https://github.com/maplibre/maplibre/files/10114728/Budget.Dec.2022.Jan.2023.Feb.2023.-.budget.pdf) for the Coordinator, Maintainer Web, and Maintainer Native roles, Harel was involved in the discussion and approved the final budget.
+
+We encourage everyone to share if they have concerns regarding the decision to contract Harel in a maintainer role while he is simultaneously a Governing Board member.
+
+The Governing Board stands unanimously behind the decision to contract Harel and is looking forward to his continued lead of MapLibre GL JS!


### PR DESCRIPTION
Twitter would be something like this:

> We are happy to share that we were able to contract Harel Mazor, the long-time lead-maintainer of MapLibre GL JS, for the Maintainer Web role. Please give him a warm welcome!