### PR TITLE
Move navigation control to bottom right corner

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -23,7 +23,7 @@ function communityMap(container, community) {
     })
   );
 
-  map.addControl(new NavigationControl());
+  map.addControl(new NavigationControl(), "bottom-right");
 
   const lngs = community.map((person) => person.latlon[1]);
   const lats = community.map((person) => person.latlon[0]);


### PR DESCRIPTION
The default position in the top-right corner makes them inaccessible because of the "Donate" banner.

See [OSM US Slack thread](https://osmus.slack.com/archives/C01G3D28DAB/p1674466211569029).