### PR TITLE
Add Mastodon link to website

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@ title = 'MapLibre'
 
 sectionPagesMenu = "main"
 
-copyright = "Creative Commons Zero v1.0 Universal"
+copyright = "CC0"
 
 enableGitInfo = true
 summaryLength = 30

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,7 +15,7 @@
     </div>
     <div class="container border-top border-gray">
       <div class="row py-3">
-        <div class="col-sm-4">
+        <div class="col-sm-6">
           <div class="nav">
             {{ range .menu }}
               <li>
@@ -27,10 +27,10 @@
           </div>
         </div>
 
-        <div class="col-sm-4">
+        <div class="col-sm-1">
           {{/* Display copyright if available */}}
           {{ with .copyright }}
-            <div class="d-flex justify-content-center text-black-50">
+            <div class="d-flex justify-content-center text-black-50 nav-link">
               {{- . -}}
             </div>
           {{ end }}
@@ -38,7 +38,7 @@
 
         <div class="col-sm-2 flex">
           {{ with .githubProjectUrl }}
-            <div class="text-black-50 d-flex justify-content-center">
+            <div class="text-black-50 d-flex justify-content-center nav-link">
               <a class="text-black-50" href="{{ . }}">GitHub</a>
               {{ with $.gitinfo }}
                 @
@@ -52,8 +52,17 @@
           {{ end }}
         </div>
 
-        <div class="col-sm-2">
+        <div class="col-sm-3">
           <div class="nav justify-content-end">
+            <a
+            class="nav-link text-black-50"
+            href="https://mastodon.social/@maplibre"
+            aria-label="MapLibre on Mastodon"
+          >
+              <svg id="mas" viewBox="0 0 16 16" width="16" height="16"  xmlns="http://www.w3.org/2000/svg">
+                <path fill="#979DA6" d="M 15.659 9.592 C 15.424 10.72 13.553 11.956 11.404 12.195 C 10.283 12.32 9.18 12.434 8.003 12.384 C 6.079 12.302 4.56 11.956 4.56 11.956 C 4.56 12.13 4.572 12.297 4.595 12.452 C 4.845 14.224 6.478 14.33 8.025 14.379 C 9.586 14.429 10.976 14.02 10.976 14.02 L 11.04 15.337 C 11.04 15.337 9.948 15.884 8.003 15.984 C 6.93 16.039 5.598 15.959 4.047 15.576 C 0.683 14.746 0.104 11.4 0.015 8.006 C -0.012 6.998 0.005 6.048 0.005 5.253 C 0.005 1.782 2.443 0.765 2.443 0.765 C 3.672 0.238 5.782 0.017 7.975 0 L 8.029 0 C 10.221 0.017 12.332 0.238 13.561 0.765 C 13.561 0.765 15.999 1.782 15.999 5.253 C 15.999 5.253 16.03 7.814 15.659 9.592 Z M 13.124 5.522 L 13.124 9.725 L 11.339 9.725 L 11.339 5.646 C 11.339 4.786 10.951 4.35 10.175 4.35 C 9.317 4.35 8.887 4.867 8.887 5.891 L 8.887 8.124 L 7.113 8.124 L 7.113 5.891 C 7.113 4.867 6.683 4.35 5.825 4.35 C 5.049 4.35 4.661 4.786 4.661 5.646 L 4.661 9.725 L 2.876 9.725 L 2.876 5.522 C 2.876 4.663 3.111 3.981 3.582 3.476 C 4.067 2.971 4.703 2.712 5.493 2.712 C 6.406 2.712 7.098 3.039 7.555 3.695 L 8 4.39 L 8.445 3.695 C 8.902 3.039 9.594 2.712 10.507 2.712 C 11.297 2.712 11.933 2.971 12.418 3.476 C 12.889 3.981 13.124 4.663 13.124 5.522 Z" style="stroke:none;stroke-miterlimit:10;fill-rule:evenodd;"/>
+              </svg>
+            </a>
             <a
               class="nav-link text-black-50"
               href="https://twitter.com/maplibre"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,6 +23,8 @@
   <meta name="twitter:image:src" content="/img/share-image.png" />
   <meta name="twitter:image:alt" content="MapLibre" />
 
+  <link rel="me" href="https://mastodon.social/@maplibre" />
+
   {{ $options := (dict "includePaths" (slice "node_modules") "transpiler" "libsass") }}
   {{ $style := resources.Get "style.scss" | resources.ToCSS $options | resources.Minify |
     resources.Fingerprint


### PR DESCRIPTION
- Add `link` tag in head so we are verified on Mastodon.
- Add icon + link in footer. I used an inline svg because I could not get the `<use ... />` syntax to work.
- I added the `nav-link` class to the footer because some footer items are not vertically aligned.
- Shortened full license to CC0 so we have more space in the footer.

![image](https://user-images.githubusercontent.com/649392/225924394-60b19781-7573-4056-95b0-65fbd1b4f331.png)
