### PR TITLE
Resize meta logo

### DIFF
--- a/content/sponsors.html
+++ b/content/sponsors.html
@@ -29,7 +29,7 @@ weight: 10
     <br />
     <br />
     <a href="https://www.meta.com/">
-      <img src="/img/meta-logo.svg" width="75%" />
+      <img src="/img/meta-logo.svg" width="50%" />
     </a>
     <br />
     <br />


### PR DESCRIPTION
The Meta logo looks just a bit too big visually on maplibre.org/sponsors. This pull request makes it the same size as the AWS logo which should look a bit better...
