### PR TITLE
Fix page titles (banner and tab title)

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -1,5 +1,5 @@
 ---
-title: Home
+title: MapLibre
 fullscreen: true
 menu: footer
 weight: -10

--- a/content/community.html
+++ b/content/community.html
@@ -29,7 +29,7 @@ type: community
 <div class="container-fluid px-0 mb-6">
   <div class="row mx-0 bg-title text-center align-items-center">
     <h1 class="text-white pt-6">
-      <span class="text-secondary">Community</span> MapLibre
+      Community
     </h1>
   </div>
 </div>

--- a/content/community.html
+++ b/content/community.html
@@ -28,9 +28,7 @@ type: community
 </style>
 <div class="container-fluid px-0 mb-6">
   <div class="row mx-0 bg-title text-center align-items-center">
-    <h1 class="text-white pt-6">
-      Community
-    </h1>
+    <h1 class="text-white pt-6">Community</h1>
   </div>
 </div>
 <div class="container">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -40,6 +40,7 @@
   {{ $built := resources.Get "main.js" | js.Build $opts | resources.Fingerprint }}  <script type="text/javascript" src="{{ $built.RelPermalink }}"></script>
 
   <title>
-    {{ .Title }} | {{ $.Site.Title }}
+    {{ .Title }} |
+    {{ $.Site.Title }}
   </title>
 </head>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -39,5 +39,7 @@
   {{ $opts := dict "targetPath" "main.js" }}
   {{ $built := resources.Get "main.js" | js.Build $opts | resources.Fingerprint }}  <script type="text/javascript" src="{{ $built.RelPermalink }}"></script>
 
-  <title>{{ $.Site.Title }} - {{ .Title }}</title>
+  <title>
+    {{ .Title }} | {{ $.Site.Title }}
+  </title>
 </head>

--- a/layouts/partials/title-header.html
+++ b/layouts/partials/title-header.html
@@ -1,7 +1,7 @@
 <div class="container-fluid px-0 mb-6">
   <div class="row mx-0 bg-title text-center align-items-center">
     <h1 class="text-white pt-6">
-      <span class="text-secondary">{{ .title }}</span> {{ .sitetitle }}
+      {{ .title }}
     </h1>
   </div>
 </div>


### PR DESCRIPTION
Both these changes are putting the content in focus, as it currently drowns a bit in "MapLibre, MapLibre, MapLibre, .."

# Tabs

**Before** 
<img width="127" alt="Screenshot 2023-05-18 at 13 11 33" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/ecaf2904-771d-4c73-9a5f-5172385f31df">
<img width="171" alt="Screenshot 2023-05-18 at 13 11 53" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/e1da1322-f1b0-4a7e-af74-c76139a495bc">



**After**
<img width="220" alt="Screenshot 2023-05-18 at 13 08 52" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/e298e40a-7863-467e-bd8c-bce20528c1b9">
<img width="203" alt="Screenshot 2023-05-18 at 13 08 43" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/eb63ebe5-f1ab-4ea1-9836-036e3f9f0486">


# Banner

**Before**
<img width="824" alt="Screenshot 2023-05-18 at 12 37 46" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/72d1cdde-2b21-403c-bde1-1b1776c22464">
<img width="1047" alt="Screenshot 2023-05-18 at 12 37 43" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/f9a141d1-5ced-48c3-8928-95f1defdc096">


**After**
<img width="619" alt="Screenshot 2023-05-18 at 12 38 30" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/a3d65821-cccc-43e3-b588-37260fb31569">
<img width="471" alt="Screenshot 2023-05-18 at 12 38 11" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/0936351d-c63f-4058-85ff-1148094aa48a">
