### PR TITLE
Update Android examples link

### DIFF
--- a/content/projects/maplibre-native/index.md
+++ b/content/projects/maplibre-native/index.md
@@ -5,7 +5,7 @@ github: https://github.com/maplibre/maplibre-native
 documentation:
   - url: https://maplibre.org/maplibre-native/android/api/
     name: Android API Documentation
-  - url: https://docs.maptiler.com/maplibre-gl-native-android/
+  - url: https://maplibre.org/maplibre-native/docs/book/android/index.html
     name: Android Examples
   - url: https://maplibre.org/maplibre-native/ios/api/
     name: iOS API Documentation


### PR DESCRIPTION
We have our own Android examples now, with more examples coming.

I think it makes sense to keep using the MdBook for this and not set up yet another static site generator.

It turns out is is able to include source code, so we can do literal programming with the example app and we will have a lot of code to draw from: https://rust-lang.github.io/mdBook/format/mdbook.html#including-portions-of-a-file