### PR TITLE
Update HubSpot job application form link

### DIFF
--- a/content/jobs.html
+++ b/content/jobs.html
@@ -110,7 +110,7 @@ weight: 10
     hbspt.forms.create({
       region: "eu1",
       portalId: "26270291",
-      formId: "17cab110-3762-4bcf-88c3-7f7fc7975099",
+      formId: "936bafe6-2d86-4628-95b9-02d68bd0fc92",
     });
   </script>
 </div>


### PR DESCRIPTION
We have a new job application form link from hubspot. The fields are still the same as before.
