### PR TITLE
Add twitter meta tags

### DIFF
--- a/content/news/2023-05-23-maplibre-gl-js-v3/index.md
+++ b/content/news/2023-05-23-maplibre-gl-js-v3/index.md
@@ -14,7 +14,7 @@ draft: false
 <meta name="twitter:creator" content="@maplibre">
 <meta name="twitter:title" content="MapLibre GL JS v3">
 <meta name="twitter:description" content="New additions in MapLibre GL JS v3 includes a full transition to WebGL2, improvements to performance, fixes to the Terrain3D, CSS4 compliant colors, hooks for better camera control and more!">
-<meta name="twitter:image" content="/img/share-image.png">
+<meta name="twitter:image" content="header.png">
 
 This release is a big step for MapLibre GL JS! With more than 500 commits, and almost a year in the making, version 3.0.0 is surely our best release yet. Lots of features, performance improvement, bug fixes and a few potentially breaking changes that were necessary, to keep the project healthy, are to be found here.
 

--- a/content/news/2023-05-23-maplibre-gl-js-v3/index.md
+++ b/content/news/2023-05-23-maplibre-gl-js-v3/index.md
@@ -9,6 +9,13 @@ authors: [birk]
 draft: false
 ---
 
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@maplibre">
+<meta name="twitter:creator" content="@maplibre">
+<meta name="twitter:title" content="MapLibre GL JS v3">
+<meta name="twitter:description" content="New additions in MapLibre GL JS v3 includes a full transition to WebGL2, improvements to performance, fixes to the Terrain3D, CSS4 compliant colors, hooks for better camera control and more!">
+<meta name="twitter:image" content="/img/share-image.png">
+
 This release is a big step for MapLibre GL JS! With more than 500 commits, and almost a year in the making, version 3.0.0 is surely our best release yet. Lots of features, performance improvement, bug fixes and a few potentially breaking changes that were necessary, to keep the project healthy, are to be found here.
 
 **A note on migration:**

--- a/content/news/2023-05-23-maplibre-gl-js-v3/index.md
+++ b/content/news/2023-05-23-maplibre-gl-js-v3/index.md
@@ -9,12 +9,14 @@ authors: [birk]
 draft: false
 ---
 
-<meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@maplibre">
-<meta name="twitter:creator" content="@maplibre">
 <meta name="twitter:title" content="MapLibre GL JS v3">
-<meta name="twitter:description" content="New additions in MapLibre GL JS v3 includes a full transition to WebGL2, improvements to performance, fixes to the Terrain3D, CSS4 compliant colors, hooks for better camera control and more!">
-<meta name="twitter:image" content="header.png">
+<meta property="twitter:domain" content="maplibre.org">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="twitter:url" content="https://maplibre.org/news/2023-05-23-maplibre-gl-js-v3/">
+<meta name="twitter:description" content="MapLibre GL JS v3 - Improvements to WebGL2, Terrain3D, Color spaces, Performance and more!">
+<meta name="twitter:image" content="https://maplibre.org/news/2023-05-23-maplibre-gl-js-v3/header.png">
+
 
 This release is a big step for MapLibre GL JS! With more than 500 commits, and almost a year in the making, version 3.0.0 is surely our best release yet. Lots of features, performance improvement, bug fixes and a few potentially breaking changes that were necessary, to keep the project healthy, are to be found here.
 

--- a/content/news/2023-05-23-maplibre-gl-js-v3/index.md
+++ b/content/news/2023-05-23-maplibre-gl-js-v3/index.md
@@ -14,7 +14,7 @@ draft: false
 <meta property="twitter:domain" content="maplibre.org">
 <meta name="twitter:card" content="summary_large_image">
 <meta property="twitter:url" content="https://maplibre.org/news/2023-05-23-maplibre-gl-js-v3/">
-<meta name="twitter:description" content="MapLibre GL JS v3 - Improvements to WebGL2, Terrain3D, Color spaces, Performance and more!">
+<meta name="twitter:description" content="MapLibre GL JS v3 - Improvements to Terrain3D, WebGL2, Color spaces, Performance and more!">
 <meta name="twitter:image" content="https://maplibre.org/news/2023-05-23-maplibre-gl-js-v3/header.png">
 
 This release is a big step for MapLibre GL JS! With more than 500 commits, and almost a year in the making, version 3.0.0 is surely our best release yet. Lots of features, performance improvement, bug fixes and a few potentially breaking changes that were necessary, to keep the project healthy, are to be found here.

--- a/content/news/2023-05-23-maplibre-gl-js-v3/index.md
+++ b/content/news/2023-05-23-maplibre-gl-js-v3/index.md
@@ -17,7 +17,6 @@ draft: false
 <meta name="twitter:description" content="MapLibre GL JS v3 - Improvements to WebGL2, Terrain3D, Color spaces, Performance and more!">
 <meta name="twitter:image" content="https://maplibre.org/news/2023-05-23-maplibre-gl-js-v3/header.png">
 
-
 This release is a big step for MapLibre GL JS! With more than 500 commits, and almost a year in the making, version 3.0.0 is surely our best release yet. Lots of features, performance improvement, bug fixes and a few potentially breaking changes that were necessary, to keep the project healthy, are to be found here.
 
 **A note on migration:**


### PR DESCRIPTION
Add cover image prepared by Duje (GL JS v3) to twitter cards - it says MapLibre all over in Title and Description, and Post text, so it shouldn't be too confusion that it's us.

Closes https://github.com/maplibre/maplibre/issues/285