### PR TITLE
make urls absolute for standard twitter img

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,7 +7,7 @@
   <meta name="description" content="{{ .Params.description }}" />
   <meta name="theme-color" content="#fff" />
 
-  <meta property="og:image" content="/img/share-image.png" />
+  <meta property="og:image" content="https://maplibre.org/img/share-image.png" />
   <meta property="og:image:width" content="1024" />
   <meta property="og:image:height" content="512" />
   <meta property="og:image:alt" content="MapLibre" />
@@ -20,7 +20,7 @@
   <meta name="twitter:creator" content="@maplibre" />
   <meta name="twitter:title" content="{{ .Title }}" />
   <meta name="twitter:description" content="{{ .Params.description }}" />
-  <meta name="twitter:image:src" content="/img/share-image.png" />
+  <meta name="twitter:image:src" content="https://maplibre.org/img/share-image.png" />
   <meta name="twitter:image:alt" content="MapLibre" />
 
   <link rel="me" href="https://mastodon.social/@maplibre" />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,7 +7,10 @@
   <meta name="description" content="{{ .Params.description }}" />
   <meta name="theme-color" content="#fff" />
 
-  <meta property="og:image" content="https://maplibre.org/img/share-image.png" />
+  <meta
+    property="og:image"
+    content="https://maplibre.org/img/share-image.png"
+  />
   <meta property="og:image:width" content="1024" />
   <meta property="og:image:height" content="512" />
   <meta property="og:image:alt" content="MapLibre" />
@@ -20,7 +23,10 @@
   <meta name="twitter:creator" content="@maplibre" />
   <meta name="twitter:title" content="{{ .Title }}" />
   <meta name="twitter:description" content="{{ .Params.description }}" />
-  <meta name="twitter:image:src" content="https://maplibre.org/img/share-image.png" />
+  <meta
+    name="twitter:image:src"
+    content="https://maplibre.org/img/share-image.png"
+  />
   <meta name="twitter:image:alt" content="MapLibre" />
 
   <link rel="me" href="https://mastodon.social/@maplibre" />


### PR DESCRIPTION
When in an embed somewhere, the /img/image.png doesn't seem to work well