### PR TITLE
Add Martin Docs link

### DIFF
--- a/content/projects/martin/index.md
+++ b/content/projects/martin/index.md
@@ -4,7 +4,9 @@ weight: 100
 github: https://github.com/maplibre/martin
 documentation:
   - url: https://martin.maplibre.org/
-    name: Intro
+    name: Demo
+  - url: https://maplibre.org/martin/
+    name: Docs
 stable: true
 ---
 


### PR DESCRIPTION
Demo: https://martin.maplibre.org
Docs: https://maplibre.org/martin

<img width="293" alt="Screenshot 2023-05-29 at 12 45 47" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/cd27600b-cc2d-46d2-9a64-0d08f4d46768">
