### PR TITLE
Remove github Donate from main menu

### DIFF
--- a/content/sponsors.html
+++ b/content/sponsors.html
@@ -79,7 +79,7 @@ weight: 10
 
   <h2 class="mt-6">GitHub Sponsors</h2>
   <p>
-    Support us today with a GitHub Sponsors donation at
+    Become a GitHub Sponsor and support us today at
 
     <a href="https://github.com/sponsors/maplibre"
       >github.com/sponsors/maplibre</a

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -56,11 +56,6 @@
             <a class="nav-link" href="{{ .URL }}">{{ .Name }}</a>
           </li>
         {{ end }}
-        <a
-          class="nav-link d-flex flex-row justify-content-between"
-          href="https://github.com/sponsors/maplibre"
-          ><span aria-hidden="true" class="me-1">♡</span> Donate</a
-        >
       </div>
     </div>
     <a


### PR DESCRIPTION
This is a small part of simplifying sitemap a bit. #189 

This donation link still exist under the sponsors page:

<img width="797" alt="Screenshot 2023-06-08 at 13 14 00" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/a66d3147-1e48-47a7-a376-de6aa73ffaf8">

<img width="1014" alt="Screenshot 2023-06-08 at 13 16 18" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/5a9e7c8c-e449-41a0-8761-cfd269d3901a">

