### PR TITLE
Move org description from jobs to about page

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -3,8 +3,27 @@ title: About
 weight: 10
 ---
 
+  <p>
+    The MapLibre Organization is an umbrella for open-source mapping libraries
+    with the two central rendering projects being
+    <a href="https://github.com/maplibre/maplibre-gl-js">MapLibre GL JS</a> and
+    <a href="https://github.com/maplibre/maplibre-native">MapLibre Native</a>
+    which are surrounded by an ecosystem of plugins and tools to generate maps.
+    The MapLibre <a href="https://maplibre.org/about/">Governing Board</a> was
+    elected by the
+    <a href="https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md"
+      >Voting Members</a
+    >, a group who represents the broader community, in August 2022 and is in
+    charge to steer the Organization. The project coordinator is
+    <a href="https://github.com/wipfli">Oliver Wipfli</a> who supports the
+    Governing Board in organizational tasks.
+  </p>
+
+<br />
 <hr/>
 <h1 class="text-center">Governing Board</h1>
+
+
 
 <div class="container">
   <div class="row justify-content-center">

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -23,8 +23,6 @@ weight: 10
 <hr/>
 <h1 class="text-center">Governing Board</h1>
 
-
-
 <div class="container">
   <div class="row justify-content-center">
     <div class="col-xl-2 text-center">

--- a/content/jobs.html
+++ b/content/jobs.html
@@ -6,21 +6,6 @@ weight: 10
 
 <div class="col-sm-8">
   <h2>Jobs</h2>
-  <p>
-    The MapLibre Organization is an umbrella for open-source mapping libraries
-    with the two central rendering projects being
-    <a href="https://github.com/maplibre/maplibre-gl-js">MapLibre GL JS</a> and
-    <a href="https://github.com/maplibre/maplibre-native">MapLibre Native</a>
-    which are surrounded by an ecosystem of plugins and tools to generate maps.
-    The MapLibre <a href="https://maplibre.org/about/">Governing Board</a> was
-    elected by the
-    <a href="https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md"
-      >Voting Members</a
-    >, a group who represents the broader community, in August 2022 and is in
-    charge to steer the Organization. The project coordinator is
-    <a href="https://github.com/wipfli">Oliver Wipfli</a> who supports the
-    Governing Board in organizational tasks.
-  </p>
 
   <p>
     Working for MapLibre means that everything you do is going to be


### PR DESCRIPTION
Part of #189 

The Jobs page had a good intro to the organization, so it's moved to the about page:

This is the jobs page after:


<img width="1022" alt="Screenshot 2023-06-08 at 13 52 06" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/6f908f80-b34c-4c0e-a8ef-d6931c23aeb3">

This is the about page after:

<img width="1499" alt="Screenshot 2023-06-08 at 13 52 00" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/5d771397-72ff-441a-a33c-29a08c6453e6">
