### PR TITLE
Adjust widths of sponsor page

### DIFF
--- a/content/sponsors.html
+++ b/content/sponsors.html
@@ -21,7 +21,7 @@ weight: 10
       <br />
       <br />
       <a href="https://aws.amazon.com/">
-        <img src="/img/aws-logo.svg" width="40%" />
+        <img src="/img/aws-logo.svg" width="40%" style="min-width: 200px;"/>
       </a>
     </p>
 
@@ -30,22 +30,22 @@ weight: 10
       <br />
       <br />
       <a href="https://www.meta.com/">
-        <img src="/img/meta-logo.svg" width="25%" />
+        <img src="/img/meta-logo.svg" width="25%" style="min-width: 150px;"/>
       </a>
       <br />
       <br />
       <a href="https://www.mierune.co.jp/?lang=en">
-        <img src="/img/mierune-logo.svg" width="25%" />
+        <img src="/img/mierune-logo.svg" width="25%" style="min-width: 150px;" />
       </a>
       <br />
       <br />
       <a href="https://komoot.com/">
-        <img src="/img/komoot-logo.svg" width="25%" />
+        <img src="/img/komoot-logo.svg" width="25%" style="min-width: 150px;"/>
       </a>
       <br />
       <br />
       <a href="https://www.jawg.io/">
-        <img src="/img/jawgmaps-logo.svg" width="25%" />
+        <img src="/img/jawgmaps-logo.svg" width="25%" style="min-width: 150px;"/>
       </a>
     </p>
 

--- a/content/sponsors.html
+++ b/content/sponsors.html
@@ -21,7 +21,7 @@ weight: 10
       <br />
       <br />
       <a href="https://aws.amazon.com/">
-        <img src="/img/aws-logo.svg" width="40%" style="min-width: 200px;"/>
+        <img src="/img/aws-logo.svg" width="40%" style="min-width: 200px;" />
       </a>
     </p>
 
@@ -29,23 +29,31 @@ weight: 10
       <b>Silver Tier:</b>
       <br />
       <br />
-      <a href="https://www.meta.com/">
-        <img src="/img/meta-logo.svg" width="25%" style="min-width: 150px;"/>
+      <a href="https://www.jawg.io/">
+        <img
+          src="/img/jawgmaps-logo.svg"
+          width="25%"
+          style="min-width: 150px;"
+        />
       </a>
       <br />
       <br />
       <a href="https://www.mierune.co.jp/?lang=en">
-        <img src="/img/mierune-logo.svg" width="25%" style="min-width: 150px;" />
+        <img
+          src="/img/mierune-logo.svg"
+          width="25%"
+          style="min-width: 150px;"
+        />
+      </a>
+      <br />
+      <br />
+      <a href="https://www.meta.com/">
+        <img src="/img/meta-logo.svg" width="25%" style="min-width: 150px;" />
       </a>
       <br />
       <br />
       <a href="https://komoot.com/">
-        <img src="/img/komoot-logo.svg" width="25%" style="min-width: 150px;"/>
-      </a>
-      <br />
-      <br />
-      <a href="https://www.jawg.io/">
-        <img src="/img/jawgmaps-logo.svg" width="25%" style="min-width: 150px;"/>
+        <img src="/img/komoot-logo.svg" width="25%" style="min-width: 150px;" />
       </a>
     </p>
 

--- a/content/sponsors.html
+++ b/content/sponsors.html
@@ -21,7 +21,7 @@ weight: 10
       <br />
       <br />
       <a href="https://aws.amazon.com/">
-        <img src="/img/aws-logo.svg" width="50%" />
+        <img src="/img/aws-logo.svg" width="40%" />
       </a>
     </p>
 
@@ -30,7 +30,7 @@ weight: 10
       <br />
       <br />
       <a href="https://www.meta.com/">
-        <img src="/img/meta-logo.svg" width="50%" />
+        <img src="/img/meta-logo.svg" width="25%" />
       </a>
       <br />
       <br />


### PR DESCRIPTION
this makes all silver tier sponsors same width, and adjust gold so it's not completely out of proportions (it seemed very large), and add a min-width so icons doesn't disappear on mobile..

before:

<img width="377" alt="Screenshot 2023-06-11 at 23 50 14" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/66131f6d-9803-47fe-b52b-c7e28aeadee8">

<img width="886" alt="Screenshot 2023-06-11 at 23 51 44" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/5327e405-b0b8-4206-8df9-942e68c27175">


after:

<img width="369" alt="Screenshot 2023-06-11 at 23 49 43" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/76283985-5d11-4a48-8624-d960af952063">

<img width="843" alt="Screenshot 2023-06-11 at 23 51 36" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/5aad53d3-2da9-4364-a754-3ce86bd5c7af">
