### PR TITLE
Update link to gl js docs

### DIFF
--- a/content/projects/maplibre-gl-js/index.md
+++ b/content/projects/maplibre-gl-js/index.md
@@ -3,11 +3,11 @@ title: "MapLibre GL JS"
 weight: -1000
 github: https://github.com/maplibre/maplibre-gl-js
 documentation:
-  - url: https://maplibre.org/maplibre-gl-js-docs
+  - url: https://maplibre.org/maplibre-gl-js/docs
     name: "API Documentation"
   - url: https://maplibre.org/maplibre-style-spec
     name: "Style Spec"
-  - url: https://maplibre.org/maplibre-gl-js-docs/plugins/
+  - url: https://maplibre.org/maplibre-gl-js/docs/plugins/
     name: "Plugins"
 stable: true
 ---


### PR DESCRIPTION
Update link of API Docs / Plugins to the new page

<img width="463" alt="Screenshot 2023-07-10 at 01 16 51" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/e01467e8-077e-4bdf-9b11-b08a974485f5">
