### PR TITLE
Fix github handle links

### DIFF
--- a/layouts/shortcodes/github-user.html
+++ b/layouts/shortcodes/github-user.html
@@ -1,2 +1,2 @@
-{{ $username := (.Get 0)  }}
+{{ $username := (.Get 0) }}
 <a href="https://github.com/{{ $username }}">@{{ $username }}</a>

--- a/layouts/shortcodes/github-user.html
+++ b/layouts/shortcodes/github-user.html
@@ -1,8 +1,2 @@
-{{ $headers := dict }}
-
-{{ if (os.Getenv "HUGO_GITHUB_TOKEN") }}
-  {{ $headers = dict "Authorization" (printf "Bearer %s" (os.Getenv "HUGO_GITHUB_TOKEN")) }}
-{{ end }}
-
-{{ $data := getJSON (printf "https://api.github.com/users/%s" (.Get 0) ) $headers }}
-<a href="{{ $data.url }}">@{{ $data.login }}</a>
+{{ $username := (.Get 0)  }}
+<a href="https://github.com/{{ $username }}">@{{ $username }}</a>


### PR DESCRIPTION
Closes #224 
Related to #223 

We currenlty use the github username to call github API to fetch the github username... As suggested, let's not do that