### PR TITLE
Add 2023 Governing Board election results news announcement

### DIFF
--- a/content/news/2023-08-30-results-governing-board-election/index.md
+++ b/content/news/2023-08-30-results-governing-board-election/index.md
@@ -1,0 +1,72 @@
+---
+title: "Results of the 2023 MapLibre Governing Board Election"
+date: 2023-08-30
+categories: ["announcements"]
+authors: [wipfli]
+draft: false
+---
+
+
+The MapLibre Governing Board Elections are finished - all existing Board members have been reelected.
+
+<hr/>
+<h1 class="text-center">MapLibre Governing Board 2023</h1>
+
+
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-xl-2 text-center">
+      <img
+        src="https://avatars.githubusercontent.com/u/74932975?v=4"
+        width="150"
+        class="rounded-circle mt-3"
+      />
+        <h3 class="m-3">Birk Skyum</h3>
+    </div>
+    <div class="col-xl-2 text-center">
+      <img
+        src="https://avatars.githubusercontent.com/u/3269297?v=4"
+        width="150"
+        class="rounded-circle mt-3"
+      />
+      <h3 class="m-3">Harel Mazor</h3>
+    </div>
+    <div class="col-xl-2 text-center">
+      <img
+        src="https://avatars.githubusercontent.com/u/157650?v=4"
+        width="150"
+        class="rounded-circle mt-3"
+      />
+        <h3 class="m-3">Luke Seelenbinder</h3>
+    </div>
+    <div class="col-xl-2 text-center">
+      <img
+        src="https://avatars.githubusercontent.com/u/59284?v=4"
+        width="150"
+        class="rounded-circle mt-3"
+      />
+        <h3 class="m-3">Petr Pridal</h3>
+    </div>
+    <div class="col-xl-2 text-center">
+      <img
+        src="https://avatars.githubusercontent.com/u/1641515?v=4"
+        width="150"
+        class="rounded-circle mt-3"
+      />
+        <h3 class="m-3">Yuri Astrakhan</h3>
+    </div>
+  </div>
+</div>
+
+<hr/>
+
+
+Congratulations to the elected Board members and a big thank you to Jonah Adkins for running for the Board as the only newcomer!
+
+Prior to the Governing Board Elections, 50 new Voting Members were nominated and confirmed by the existing Voting Members. This means that there are now 93 MapLibre Voting Members in total, see [list of all Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md).
+
+Out of the 93 Voting Members, 58 participated in the vote, resulting in a voter turnout of 62 percent.
+
+Since the voting body is a small group of people, we used ranked-choice voting based on the Meek STV method. For a detailed run-down of the calculation, see the [voting results](https://github.com/maplibre/maplibre/blob/main/2023-polls/MapLibre-Governing-Board-Election-Results.pdf).
+
+Thanks to all Voting Members for participating in the election, and thanks to all new Governing Board members for volunteering your time for MapLibre!


### PR DESCRIPTION
Adds a news annoucnement about the eleciton results.

The tweet will be the first line of the article, i.e., "The MapLibre Governing Board Elections are finished - all existing Board members have been reelected. Read more at..."
