### PR TITLE
Add rss/atom feed to header

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -49,4 +49,8 @@
     {{ .Title }} |
     {{ $.Site.Title }}
   </title>
+
+  {{ range .AlternativeOutputFormats -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+  {{ end -}}
 </head>


### PR DESCRIPTION
Following https://gohugo.io/templates/rss/ this add `<link rel="alternate" type="application/rss+xml" href="http://localhost:1313/news/index.xml" title="MapLibre" />` to the `head`.

<img width="849" alt="image" src="https://github.com/maplibre/maplibre.github.io/assets/111561/a2d3056f-f3de-4f7f-8f86-a57f9f391184">


---

Closes https://github.com/maplibre/maplibre.github.io/issues/221