### PR TITLE
Improved badge and header color

### DIFF
--- a/assets/custom.scss
+++ b/assets/custom.scss
@@ -10,8 +10,7 @@ body {
 }
 
 .badge {
-    background-color: #95BEFA !important;
-  
+  background-color: #95befa !important;
 
   path,
   a {

--- a/assets/custom.scss
+++ b/assets/custom.scss
@@ -10,12 +10,13 @@ body {
 }
 
 .badge {
-  background-color: #1058c0 !important;
+    background-color: #95BEFA !important;
+  
 
   path,
   a {
-    color: white !important;
-    fill: white !important;
+    color: #111725 !important;
+    fill: #111725 !important;
   }
 }
 

--- a/assets/custom.scss
+++ b/assets/custom.scss
@@ -4,6 +4,14 @@ body {
   background-color: $background;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5 {
+  color: white !important;
+}
+
 .badge {
   font-size: 14px;
   margin: 2px 0px;


### PR DESCRIPTION
Tweak of badge colors. It's a bit more calm

current:
<img width="646" alt="Screenshot 2023-10-22 at 16 26 25" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/89e48b2c-72d6-4a80-831a-8ff85c5f1b57">



new:
<img width="675" alt="Screenshot 2023-10-22 at 16 26 05" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/ee91d10f-bb43-4bf3-95a0-06dada2655f3">


Also fixed header colors, so that they are clean white:

before:
<img width="752" alt="Screenshot 2023-10-22 at 16 33 40" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/77f6b06c-28a3-4cb8-a34e-0ec814db292b">


after:
<img width="867" alt="Screenshot 2023-10-22 at 16 33 17" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/93da90da-c82c-44ce-9889-b5738e47ccd8">
