### PR TITLE
Fix jumping nav bar

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,6 +7,7 @@
         <div class="col-6">
           <a href="/" aria-label="MapLibre">
             <object
+              height="30"
               width="120"
               data="/img/maplibre-logo.svg"
               type="image/svg+xml"

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -8,6 +8,7 @@
   <div class="container">
     <a class="navbar-brand" href="/" aria-label="MapLibre">
       <object
+        height="30"
         width="120"
         data="/img/maplibre-logo.svg"
         type="image/svg+xml"


### PR DESCRIPTION
When changing between pages, the navbar jumps, because the logo loads too tall on pageload. This fixes that,