### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -131,7 +131,7 @@ function terrain3dMap(container) {
       sources: {
         osm: {
           type: "raster",
-          tiles: ["https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"],
+          tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
           tileSize: 256,
           attribution: "&copy; OpenStreetMap Contributors",
           maxzoom: 19,

--- a/content/news/2022-05-20-terrain3d.md
+++ b/content/news/2022-05-20-terrain3d.md
@@ -69,7 +69,7 @@ Here is a stand-alone Terrain3D example:
           sources: {
             osm: {
               type: "raster",
-              tiles: ["https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"],
+              tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
               tileSize: 256,
               attribution: "&copy; OpenStreetMap Contributors",
               maxzoom: 19,


### PR DESCRIPTION
I would like to suggest using the now preferred https://tile.openstreetmap.org URL instead of the current one, see

https://github.com/openstreetmap/operations/issues/737