### PR TITLE
make roadmap readable

### DIFF
--- a/content/roadmap/_index.md
+++ b/content/roadmap/_index.md
@@ -3,6 +3,16 @@ title: Roadmap
 weight: 10
 ---
 
+<style>
+  .card{
+    background-color: #1e3150;
+
+    > img {
+      background-color: white;
+    }
+  }
+</style>
+
 <div class="alert alert-success" role="alert">
 <b>Bounties:</b> Some projects on our Roadmap have Bounties, i.e., you can get paid for working on them.
 <a class="btn btn-primary" href="step-by-step-bounties-guide">Read Step-by-Step Bounties Guide...</a>


### PR DESCRIPTION
before
<img width="431" alt="Screenshot 2023-12-01 at 01 19 20" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/23bf424b-f741-472e-814c-f988777dceaa">

after
<img width="437" alt="Screenshot 2023-12-01 at 01 19 25" src="https://github.com/maplibre/maplibre.github.io/assets/74932975/86bdd4e2-ad22-4a1b-934c-caadd9146792">

