### PR TITLE
Improve Android link; add myself to the community map

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -131,7 +131,7 @@ weight: -10
 
               <span class="badge bg-primary text-white"
                 ><a href="https://maplibre.org/maplibre-native/android/api/"
-                  >API Documentation</a
+                  >Android API Documentation</a
                 ></span
               >
               <span class="badge bg-primary text-white"

--- a/data/community.json
+++ b/data/community.json
@@ -506,5 +506,9 @@
   {
     "github": "hallahan",
     "latlon": [37.0125909, -121.8433058]
+  },
+  {
+    "github": "ianthetechie",
+    "latlon": [37.670157, 126.59667]
   }
 ]


### PR DESCRIPTION
Should be pretty straightforward. I always get a bit bugged when I see "API Documentation" as if it were _the_ MapLibre native (C++) API 😂 