### PR TITLE
Update iOS Documentation Link

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -131,7 +131,7 @@ weight: -10
 
               <span class="badge bg-primary text-white"
                 ><a href="https://maplibre.org/maplibre-native/android/api/"
-                  >Android API Documentation</a
+                  >Android API</a
                 ></span
               >
               <span class="badge bg-primary text-white"
@@ -143,7 +143,7 @@ weight: -10
               <span class="badge bg-primary text-white"
                 ><a
                   href="https://maplibre.org/maplibre-native/ios/latest/documentation/maplibre"
-                  >iOS API Documentation</a
+                  >iOS Documentation</a
                 ></span
               >
               <span class="badge bg-primary text-white"


### PR DESCRIPTION
The [iOS documentation](https://maplibre.org/maplibre-native/ios/latest/documentation/maplibre/) hosted by MapLibre now has some examples, it's no longer just API documentation. This PR updates the link text to reflect that.

The MapTiler iOS examples haven't been updated for 6.0.0, so I removed the link because it may be confusing. It's still useful for UIKit, but we should host our own documentation. Thanks MapTiler for bridging the gap with the very scarce documentation for MapLibre Native iOS the past few years.