### PR TITLE
Remove iOS Examples LInk

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -147,11 +147,6 @@ weight: -10
                 ></span
               >
               <span class="badge bg-primary text-white"
-                ><a href="https://docs.maptiler.com/maplibre-gl-native-ios/"
-                  >iOS Examples</a
-                ></span
-              >
-              <span class="badge bg-primary text-white"
                 ><a href="https://maplibre.org/maplibre-native/cpp/api/"
                   >Core C++ API</a
                 ></span


### PR DESCRIPTION
Outdated and examples are now part of MapLibre iOS Documentation.

I intended to include this in https://github.com/maplibre/maplibre.github.io/pull/314