### PR TITLE
Link to Maputnik

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -240,7 +240,7 @@ weight: -10
             />
 
             <a
-              href="https://github.com/maplibre/maputnik"
+              href="https://maplibre.org/maputnik"
               style="background-image: url('/img/maputnik.png'); height: 300px; width:100%;max-width: 150px; background-size:contain; background-position: center; background-repeat: no-repeat;"
             >
             </a>

--- a/content/_index.html
+++ b/content/_index.html
@@ -223,7 +223,7 @@ weight: -10
                 ></span
               >
               <span class="badge bg-primary text-white"
-                ><a href="https://github.com/maplibre/maputnik"
+                ><a href="https://maplibre.org/maputnik"
                   >Maputnik Style Editor</a
                 ></span
               >


### PR DESCRIPTION
I think we should link to Maptunik itself from the homepage rather than the GitHub repo.