### PR TITLE
Cleanup Roadmap page

### DIFF
--- a/src/components/TitleHeader.astro
+++ b/src/components/TitleHeader.astro
@@ -1,4 +1,4 @@
-<div class="container-fluid px-0 mb-6">
+<div class="container-fluid px-0 mb-3">
   <div class="row mx-0 bg-title text-center align-items-center">
     <h1 class="text-white pt-6">
       <slot />

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -33,8 +33,12 @@ const bios = defineCollection({
 
 const roadmapItems = defineCollection({
   loader: glob({ pattern: "**/*.mdx", base: "./src/content/roadmap" }),
-  schema: z.object({
+  schema: ({ image }) => z.object({
     title: z.string(),
+    heroImage: image(),
+    status: z.enum(['under-consideration', 'in-progress', 'released']),
+    bountyLink: z.optional(z.string()),
+    bountyActive: z.optional(z.boolean()),
   }),
 });
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -33,13 +33,14 @@ const bios = defineCollection({
 
 const roadmapItems = defineCollection({
   loader: glob({ pattern: "**/*.mdx", base: "./src/content/roadmap" }),
-  schema: ({ image }) => z.object({
-    title: z.string(),
-    heroImage: image(),
-    status: z.enum(['under-consideration', 'in-progress', 'released']),
-    bountyLink: z.optional(z.string()),
-    bountyActive: z.optional(z.boolean()),
-  }),
+  schema: ({ image }) =>
+    z.object({
+      title: z.string(),
+      heroImage: image(),
+      status: z.enum(["under-consideration", "in-progress", "released"]),
+      bountyLink: z.optional(z.string()),
+      bountyActive: z.optional(z.boolean()),
+    }),
 });
 
 export const collections = { news, authors, bios, roadmapItems };

--- a/src/content/roadmap/blending-modes/index.mdx
+++ b/src/content/roadmap/blending-modes/index.mdx
@@ -1,21 +1,14 @@
 ---
 title: Blending Modes
+heroImage: './image.png'
+status: under-consideration
+bountyActive: true
+bountyLink: https://github.com/maplibre/maplibre/issues/269
 ---
-
-import { Image } from "astro:assets";
-import terrain from "./image.png";
 
 Goal:
 
 - Enable per-layer or per-feature blending modes as multiply, add, overlay, lighten, darken, etc.
-
-<p>
-  <Image
-    alt="terrain"
-    src={terrain}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/7/77/Hue_alpha_falloff.svg">Wikipedia</a>
 

--- a/src/content/roadmap/blending-modes/index.mdx
+++ b/src/content/roadmap/blending-modes/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Blending Modes
-heroImage: './image.png'
+heroImage: "./image.png"
 status: under-consideration
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/269

--- a/src/content/roadmap/community-governance/index.mdx
+++ b/src/content/roadmap/community-governance/index.mdx
@@ -1,12 +1,11 @@
 ---
 title: Community & Governance
-heroImage: './image.png'
+heroImage: "./image.png"
 status: released
 ---
 
 Kick-off the community & setup governance for the project
 
 https://www.maptiler.com/news/2021/01/mapbox-gl-open-source-fork/
-
 
 Released: January 2021

--- a/src/content/roadmap/community-governance/index.mdx
+++ b/src/content/roadmap/community-governance/index.mdx
@@ -1,20 +1,12 @@
 ---
 title: Community & Governance
+heroImage: './image.png'
+status: released
 ---
-
-import { Image } from "astro:assets";
-import governance from "./image.png";
 
 Kick-off the community & setup governance for the project
 
 https://www.maptiler.com/news/2021/01/mapbox-gl-open-source-fork/
 
-<p>
-  <Image
-    alt="governance"
-    src={governance}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 Released: January 2021

--- a/src/content/roadmap/documentation/index.mdx
+++ b/src/content/roadmap/documentation/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Documentation
-heroImage: './image.png'
+heroImage: "./image.png"
 status: in-progress
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/191

--- a/src/content/roadmap/documentation/index.mdx
+++ b/src/content/roadmap/documentation/index.mdx
@@ -1,20 +1,15 @@
 ---
 title: Documentation
+heroImage: './image.png'
+status: in-progress
+bountyActive: true
+bountyLink: https://github.com/maplibre/maplibre/issues/191
 ---
-
-import { Image } from "astro:assets";
-import docs from "./image.png";
 
 Goals:
 
 - Write tutorials and getting started guides to help people migrate existing projects to MapLibre or help them with new map rendering projects.
 - Modernize documentation tooling to meet today's best practices and most widely adopted solutions.
-
-<Image
-  alt="Documentation"
-  src={docs}
-  style="height: auto; background-color: white;max-width:600px;width:100%"
-/>
 
 GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/191
 

--- a/src/content/roadmap/globe-view/index.mdx
+++ b/src/content/roadmap/globe-view/index.mdx
@@ -1,22 +1,15 @@
 ---
 title: Globe View
+heroImage: './image.png'
+status: in-progress
+bountyActive: true
+bountyLink: https://github.com/maplibre/maplibre/issues/190
 ---
-
-import { Image } from "astro:assets";
-import globe from "./image.png";
 
 Goals:
 
 - Zoom out via Adaptive Composite Map Projection
 - Ability to show and interact with Globe (or alternative view on earth) when map is zoomed out - while reusing and loading the same Mercator vector tile and raster data - client side reprojection of the data - using Adaptive Composite Map Projection - where deeply zoomed you are in Mercator - but from certain zoom level up there is transition to another projection.
-
-<p>
-  <Image
-    alt="globe"
-    src={globe}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/190
 

--- a/src/content/roadmap/globe-view/index.mdx
+++ b/src/content/roadmap/globe-view/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Globe View
-heroImage: './image.png'
+heroImage: "./image.png"
 status: in-progress
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/190

--- a/src/content/roadmap/ios-android-release/index.mdx
+++ b/src/content/roadmap/ios-android-release/index.mdx
@@ -1,21 +1,12 @@
 ---
 title: iOS and Android SDK Release
+heroImage: './image.png'
+status: released
 ---
-
-import { Image } from "astro:assets";
-import mobileSDK from "./image.png";
 
 Public release of Android & iOS open-source SDK
 
 https://www.maptiler.com/news/2021/06/maplibre-gl-native-open-source-mobile-sdk-for-android-and-ios/
-
-<p>
-  <Image
-    alt="mobile sdk"
-    src={mobileSDK}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 GitHub: https://github.com/maplibre/maplibre-native
 

--- a/src/content/roadmap/ios-android-release/index.mdx
+++ b/src/content/roadmap/ios-android-release/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: iOS and Android SDK Release
-heroImage: './image.png'
+heroImage: "./image.png"
 status: released
 ---
 

--- a/src/content/roadmap/js-docs/index.mdx
+++ b/src/content/roadmap/js-docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: JS Documentation Website
-heroImage: './image.png'
+heroImage: "./image.png"
 status: released
 ---
 

--- a/src/content/roadmap/js-docs/index.mdx
+++ b/src/content/roadmap/js-docs/index.mdx
@@ -1,19 +1,10 @@
 ---
 title: JS Documentation Website
+heroImage: './image.png'
+status: released
 ---
 
-import { Image } from "astro:assets";
-import GLJSDocs from "./image.png";
-
 Publish examples and reference docs for GL JS: https://maplibre.org/maplibre-gl-js-docs/api/
-
-<p>
-  <Image
-    alt="GL JS Docs"
-    src={GLJSDocs}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 GitHub repository: https://github.com/maplibre/maplibre-gl-js-docs
 

--- a/src/content/roadmap/lightweight-renderers/index.mdx
+++ b/src/content/roadmap/lightweight-renderers/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Lightweight Renderers
-heroImage: './image.png'
+heroImage: "./image.png"
 status: under-consideration
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/273

--- a/src/content/roadmap/lightweight-renderers/index.mdx
+++ b/src/content/roadmap/lightweight-renderers/index.mdx
@@ -1,21 +1,14 @@
 ---
 title: Lightweight Renderers
+heroImage: './image.png'
+status: under-consideration
+bountyActive: true
+bountyLink: https://github.com/maplibre/maplibre/issues/273
 ---
-
-import { Image } from "astro:assets";
-import lightweightRenderers from "./image.png";
 
 Goal:
 
 - Generate smaller builds for the MapLibre library for Web and Native
-
-<p>
-  <Image
-    alt="lightweight renderers"
-    src={lightweightRenderers}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 Image Credit: <a href="https://openverse.org/image/9dc5204d-ef38-4921-9b56-4f225741a2f3?q=renderer%20blocks">Openverse</a>
 

--- a/src/content/roadmap/metal/index.mdx
+++ b/src/content/roadmap/metal/index.mdx
@@ -1,19 +1,10 @@
 ---
 title: Metal
+heroImage: './image.png'
+status: released
 ---
 
-import { Image } from "astro:assets";
-import metal from "./image.png";
-
 Implement a Metal graphics backend to ensure iOS in future releases is fully supported, as Apple is deprecating OpenGL.
-
-<p>
-  <Image
-    alt="metal"
-    src={metal}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 First, the codebase shall be modularized to prepare the existing OpenGL architecture for a more modern graphics backend like Metal. Once the renderer is modularized, we will proceed with implementing the actual Metal redering backend.
 

--- a/src/content/roadmap/metal/index.mdx
+++ b/src/content/roadmap/metal/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Metal
-heroImage: './image.png'
+heroImage: "./image.png"
 status: released
 ---
 

--- a/src/content/roadmap/modernize-codebase/index.mdx
+++ b/src/content/roadmap/modernize-codebase/index.mdx
@@ -1,21 +1,14 @@
 ---
 title: Modernize Codebase
+heroImage: './image.png'
+status: in-progress
+bountyActive: true
+bountyLink: https://github.com/maplibre/maplibre/issues/270
 ---
-
-import { Image } from "astro:assets";
-import modernize from "./image.png";
 
 Goal:
 
 - Modernize Kotlin, Swift and TypeScript codebase
-
-<p>
-  <Image
-    alt="modernize"
-    src={modernize}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/Globe_logo.svg/1142px-Globe_logo.svg.png">Wikipedia</a>
 

--- a/src/content/roadmap/modernize-codebase/index.mdx
+++ b/src/content/roadmap/modernize-codebase/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Modernize Codebase
-heroImage: './image.png'
+heroImage: "./image.png"
 status: in-progress
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/270

--- a/src/content/roadmap/non-mercator-projection/index.mdx
+++ b/src/content/roadmap/non-mercator-projection/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Non-Mercator Projection
-heroImage: './image.png'
+heroImage: "./image.png"
 status: under-consideration
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/272

--- a/src/content/roadmap/non-mercator-projection/index.mdx
+++ b/src/content/roadmap/non-mercator-projection/index.mdx
@@ -1,23 +1,16 @@
 ---
 title: Non-Mercator Projection
+heroImage: './image.png'
+status: under-consideration
+bountyActive: true
+bountyLink: https://github.com/maplibre/maplibre/issues/272
 ---
-
-import { Image } from "astro:assets";
-import nonMercatorProjection from "./image.png";
 
 Goals:
 
 - Initialize an entire view of the map in a non-Mercator projection
 - Load and display vector tiles produced in custom coordinate systems
 - Specify EPSG coordinate system and tile matrix set
-
-<p>
-  <Image
-    alt="non-mercator projections"
-    src={nonMercatorProjection}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/f/fa/Mercator-proj.png">Wikipedia</a>
 

--- a/src/content/roadmap/performance/index.mdx
+++ b/src/content/roadmap/performance/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Performance
-heroImage: './image.png'
+heroImage: "./image.png"
 status: in-progress
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/192

--- a/src/content/roadmap/performance/index.mdx
+++ b/src/content/roadmap/performance/index.mdx
@@ -1,23 +1,16 @@
 ---
 title: Performance
+heroImage: './image.png'
+status: in-progress
+bountyActive: true
+bountyLink: https://github.com/maplibre/maplibre/issues/192
 ---
-
-import { Image } from "astro:assets";
-import performance from "./image.png";
 
 Goals:
 
 - Speed - initialization and rendering
 - Optimization related to initialization time of the rendering libraries, delay before the map appears in the app.
 - Rendering performance improvements, measurement, test and best-practice documentation.
-
-<p>
-  <Image
-    alt="performance"
-    src={performance}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/3/33/Cartoon_space_rocket.png">Wikipedia</a>
 

--- a/src/content/roadmap/project-website/index.mdx
+++ b/src/content/roadmap/project-website/index.mdx
@@ -1,19 +1,10 @@
 ---
 title: Project Website
+heroImage: './image.png'
+status: released
 ---
 
-import { Image } from "astro:assets";
-import projectWebsite from "./image.png";
-
 Launch first version of https://maplibre.org
-
-<p>
-  <Image
-    alt="maplibre.org"
-    src={projectWebsite}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 GitHub repository: https://github.com/maplibre/maplibre.github.io
 

--- a/src/content/roadmap/project-website/index.mdx
+++ b/src/content/roadmap/project-website/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Project Website
-heroImage: './image.png'
+heroImage: "./image.png"
 status: released
 ---
 

--- a/src/content/roadmap/svg-symbol-source/index.mdx
+++ b/src/content/roadmap/svg-symbol-source/index.mdx
@@ -1,21 +1,14 @@
 ---
 title: SVG Symbol Source
+heroImage: './image.png'
+status: under-consideration
+bountyActive: true
+bountyLink: https://github.com/maplibre/maplibre/issues/271
 ---
-
-import { Image } from "astro:assets";
-import svgSymbolSource from "./image.png";
 
 Goal:
 
 - Use SVG as a symbol source
-
-<p>
-  <Image
-    alt="svg symbol source"
-    src={svgSymbolSource}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/SVG_logo.svg/768px-SVG_logo.svg.png">Wikipedia</a>
 

--- a/src/content/roadmap/svg-symbol-source/index.mdx
+++ b/src/content/roadmap/svg-symbol-source/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: SVG Symbol Source
-heroImage: './image.png'
+heroImage: "./image.png"
 status: under-consideration
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/271

--- a/src/content/roadmap/terrain3d-improvements/index.mdx
+++ b/src/content/roadmap/terrain3d-improvements/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Terrain3D Improvements
-heroImage: './image.png'
+heroImage: "./image.png"
 status: in-progress
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/189

--- a/src/content/roadmap/terrain3d-improvements/index.mdx
+++ b/src/content/roadmap/terrain3d-improvements/index.mdx
@@ -1,23 +1,16 @@
 ---
 title: Terrain3D Improvements
+heroImage: './image.png'
+status: in-progress
+bountyActive: true
+bountyLink: https://github.com/maplibre/maplibre/issues/189
 ---
-
-import { Image } from "astro:assets";
-import terrainImprovements from "./image.png";
 
 Goals:
 
 - 3D terrain visualization and parity web - native
 - Visualization of the elevation from DEM (RGBA tiles) including drawing the tracks, labels and points.
 - Improvements related to 3d terrain rendering - improvements and bug-fixing in existing Web implementation, implementation in Native, documentation.
-
-<p>
-  <Image
-    alt="terrain improvements"
-    src={terrainImprovements}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/189
 

--- a/src/content/roadmap/terrain3d/index.mdx
+++ b/src/content/roadmap/terrain3d/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Terrain3D
-heroImage: './image.png'
+heroImage: "./image.png"
 status: released
 ---
 

--- a/src/content/roadmap/terrain3d/index.mdx
+++ b/src/content/roadmap/terrain3d/index.mdx
@@ -1,21 +1,12 @@
 ---
 title: Terrain3D
+heroImage: './image.png'
+status: released
 ---
-
-import { Image } from "astro:assets";
-import terrain3d from "./image.png";
 
 Visualization of the elevation from DEM (RGBA tiles) including drawing the tracks, labels and points.
 
 Make a first release of Terrain3D in MapLibre GL JS.
-
-<p>
-  <Image
-    alt="terrain 3d"
-    src={terrain3d}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 GitHub Pull Request: https://github.com/maplibre/maplibre-gl-js/pull/165
 

--- a/src/content/roadmap/typescript/index.mdx
+++ b/src/content/roadmap/typescript/index.mdx
@@ -1,19 +1,10 @@
 ---
 title: TypeScript
+heroImage: './image.jpeg'
+status: released
 ---
 
-import { Image } from "astro:assets";
-import typescript from "./image.jpeg";
-
 Convert the entire library into TypeScript - add types & improve tests while remaining compatible on the API level.
-
-<p>
-  <Image
-    alt="typescript"
-    src={typescript}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 GitHub tracking issue: https://github.com/maplibre/maplibre-gl-js/issues/32
 

--- a/src/content/roadmap/typescript/index.mdx
+++ b/src/content/roadmap/typescript/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: TypeScript
-heroImage: './image.jpeg'
+heroImage: "./image.jpeg"
 status: released
 ---
 

--- a/src/content/roadmap/vulkan/index.mdx
+++ b/src/content/roadmap/vulkan/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vulkan
-heroImage: './image.png'
+heroImage: "./image.png"
 status: released
 ---
 

--- a/src/content/roadmap/vulkan/index.mdx
+++ b/src/content/roadmap/vulkan/index.mdx
@@ -1,9 +1,8 @@
 ---
 title: Vulkan
+heroImage: './image.png'
+status: released
 ---
-
-import { Image } from "astro:assets";
-import Vulkan from "./image.png";
 
 [Vulkan](https://www.vulkan.org/) is a next-generation graphics API developed by the Khronos Group. In December 2024, MapLibre Android with Vulkan support was released. It is available as a separate package from Maven Central as [`org.maplibre.gl:android-sdk-vulkan`](https://central.sonatype.com/artifact/org.maplibre.gl/android-sdk-vulkan).
 

--- a/src/content/roadmap/writing-systems/index.mdx
+++ b/src/content/roadmap/writing-systems/index.mdx
@@ -1,21 +1,14 @@
 ---
 title: Writing Systems
+heroImage: './image.png'
+status: in-progress
+bountyActive: true
+bountyLink: https://github.com/maplibre/maplibre/issues/193
 ---
-
-import { Image } from "astro:assets";
-import writingSystems from "./image.png";
 
 Goals:
 
 - Support text rendering for more languages, in particular Brahmic/Indic scripts.
-
-<p>
-  <Image
-    alt="writing systems"
-    src={writingSystems}
-    style="max-width:600px;height:auto;width:100%"
-  />
-</p>
 
 Image Credit: <a href="https://en.wikipedia.org/wiki/Brahmic_scripts#/media/File:Different_scripts_of_different_languages_of_India.jpg">Wikipedia</a>
 

--- a/src/content/roadmap/writing-systems/index.mdx
+++ b/src/content/roadmap/writing-systems/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Writing Systems
-heroImage: './image.png'
+heroImage: "./image.png"
 status: in-progress
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/193

--- a/src/pages/roadmap/[...slug].astro
+++ b/src/pages/roadmap/[...slug].astro
@@ -16,6 +16,13 @@ export async function getStaticPaths() {
 type Props = CollectionEntry<"roadmapItems">;
 const roadmapItem = Astro.props;
 const { Content } = await render(roadmapItem);
+
+import { Image } from "astro:assets";
+// import  heroImage from `../../content/roadmap/${roadmapItem.id}/${roadmapItem.data.heroImage}`;
+
+// const images = import.meta.glob<{ default: ImageMetadata }>('/src/content/roadmap/**/*.{jpeg,jpg,png,gif}');
+// console.log(images)
+
 ---
 
 <Layout title={roadmapItem.data.title}>
@@ -23,6 +30,12 @@ const { Content } = await render(roadmapItem);
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-md-10 col-lg-8">
+        <Image
+        format="png"
+          alt={roadmapItem.data.title}
+          src={roadmapItem.data.heroImage}
+          style="max-width:600px;height:auto;width:100%; border-radius: 10px; background-color: white; display: block; margin: 0 auto 20px auto;"
+        />
         <Content />
       </div>
     </div>

--- a/src/pages/roadmap/[...slug].astro
+++ b/src/pages/roadmap/[...slug].astro
@@ -16,12 +16,7 @@ export async function getStaticPaths() {
 type Props = CollectionEntry<"roadmapItems">;
 const roadmapItem = Astro.props;
 const { Content } = await render(roadmapItem);
-
 import { Image } from "astro:assets";
-// import  heroImage from `../../content/roadmap/${roadmapItem.id}/${roadmapItem.data.heroImage}`;
-
-// const images = import.meta.glob<{ default: ImageMetadata }>('/src/content/roadmap/**/*.{jpeg,jpg,png,gif}');
-// console.log(images)
 ---
 
 <Layout title={roadmapItem.data.title}>

--- a/src/pages/roadmap/[...slug].astro
+++ b/src/pages/roadmap/[...slug].astro
@@ -22,7 +22,6 @@ import { Image } from "astro:assets";
 
 // const images = import.meta.glob<{ default: ImageMetadata }>('/src/content/roadmap/**/*.{jpeg,jpg,png,gif}');
 // console.log(images)
-
 ---
 
 <Layout title={roadmapItem.data.title}>
@@ -31,7 +30,7 @@ import { Image } from "astro:assets";
     <div class="row justify-content-center">
       <div class="col-md-10 col-lg-8">
         <Image
-        format="png"
+          format="png"
           alt={roadmapItem.data.title}
           src={roadmapItem.data.heroImage}
           style="max-width:600px;height:auto;width:100%; border-radius: 10px; background-color: white; display: block; margin: 0 auto 20px auto;"

--- a/src/pages/roadmap/index.astro
+++ b/src/pages/roadmap/index.astro
@@ -1,28 +1,32 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import { Image } from "astro:assets";
-import terrain3dImprovementsImage from "../../content/roadmap/terrain3d-improvements/image.png";
-import documentationImage from "../../content/roadmap/documentation/image.png";
-import modernizeCodebaseImage from "../../content/roadmap/modernize-codebase/image.png";
-import globeViewImage from "../../content/roadmap/globe-view/image.png";
-import writingSystemsImage from "../../content/roadmap/writing-systems/image.png";
-import performanceImage from "../../content/roadmap/performance/image.png";
-import vulkanImage from "../../content/roadmap/vulkan/image.png";
-import blendingModesImage from "../../content/roadmap/blending-modes/image.png";
-import svgSymbolSourceImage from "../../content/roadmap/svg-symbol-source/image.png";
-import nonMercatorProjectionImage from "../../content/roadmap/non-mercator-projection/image.png";
-import lightweightRenderersImage from "../../content/roadmap/lightweight-renderers/image.png";
-import metalImage from "../../content/roadmap/metal/image.png";
-import terrain3dImage from "../../content/roadmap/terrain3d/image.png";
-import communityGovernanceImage from "../../content/roadmap/community-governance/image.png";
-import iosAndroidReleaseImage from "../../content/roadmap/ios-android-release/image.png";
-import jsDocsImage from "../../content/roadmap/js-docs/image.png";
-import typescriptImage from "../../content/roadmap/typescript/image.jpeg";
-import projectWebsiteImage from "../../content/roadmap/project-website/image.png";
+import TitleHeader from "../../components/TitleHeader.astro";
+import { getCollection } from "astro:content";
 title: "Roadmap";
+
+const roadmapItems = (await getCollection("roadmapItems"));
+
+const sections = [
+  {
+    status: "in-progress",
+    title: "In Progress",
+  },
+  {
+    status: "under-consideration",
+    title: "Under Consideration",
+  },
+  {
+    status: "released",
+    title: "Released",
+  }
+]
+
 ---
 
 <Layout title="Roadmap">
+
+  <TitleHeader>Roadmap</TitleHeader>
   <style>
     .card {
       background-color: #1e3150;
@@ -42,359 +46,42 @@ title: "Roadmap";
     </div>
 
     <hr />
-    <h2>In Progress</h2>
 
-    <div class="row gy-4">
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={terrain3dImprovementsImage}
-            alt="Terrain3D Improvements"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">Terrain3D Improvements</h5>
-            <a href="roadmap/terrain3d-improvements/" class="btn btn-primary"
-              >Read more...</a
-            >
-            <a
-              href="https://github.com/maplibre/maplibre/issues/189"
-              class="btn btn-light">💰 Bounties</a
-            >
-          </div>
-        </div>
-      </div>
-
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={documentationImage}
-            alt="Documentation"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">Documentation</h5>
-            <a href="roadmap/documentation/" class="btn btn-primary"
-              >Read more...</a
-            >
-            <a
-              href="https://github.com/maplibre/maplibre/issues/191"
-              class="btn btn-light">💰 Bounties</a
-            >
-          </div>
-        </div>
-      </div>
-
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={modernizeCodebaseImage}
-            alt="Modernize Codebase"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">Modernize Codebase</h5>
-            <a href="roadmap/modernize-codebase/" class="btn btn-primary"
-              >Read more...</a
-            >
-            <a
-              href="https://github.com/maplibre/maplibre/issues/270"
-              class="btn btn-light">💰 Bounties</a
-            >
-          </div>
-        </div>
-      </div>
-
-      <div class="row gy-4">
-        <div class="col-lg-4">
-          <div class="card">
+    {sections.map(section=>(
+    <h2>{section.title}</h2>
+    <style>
+      .grid-container {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 1rem;
+      margin-bottom: 50px;
+      }
+    </style>
+    <div class="grid-container">
+      {roadmapItems.filter(item => item.data.status == section.status).map(item => {
+      return (
+      <div class="card">
             <Image
               class="card-img-top"
-              src={globeViewImage}
-              alt="Globe View"
+              src={item.data.heroImage}
+              alt={item.data.title}
               style="width: 100%; height: 250px; object-fit: cover;"
             />
             <div class="card-body">
-              <h5 class="card-title">Globe View</h5>
-              <a href="roadmap/globe-view/" class="btn btn-primary"
-                >Read more...</a
-              >
-              <a
-                href="https://github.com/maplibre/maplibre/issues/190"
-                class="btn btn-light">💰 Bounties</a
-              >
+              <h5 class="card-title">{item.data.title}</h5>
+              <a href={`roadmap/${item.id}`} class="btn btn-primary"
+                >Read more...</a>
+              {item.data.bountyActive ? <a
+                href={item.data.bountyLink}
+                class="btn btn-light">💰 Bounties</a>
+              : null}
             </div>
           </div>
-        </div>
+          )
+      })}
 
-        <div class="col-lg-4">
-          <div class="card">
-            <Image
-              class="card-img-top"
-              src={writingSystemsImage}
-              alt="Writing Systems"
-              style="width: 100%; height: 250px; object-fit: cover;"
-            />
-            <div class="card-body">
-              <h5 class="card-title">Writing Systems</h5>
-              <a href="roadmap/writing-systems/" class="btn btn-primary"
-                >Read more...</a
-              >
-              <a
-                href="https://github.com/maplibre/maplibre/issues/193"
-                class="btn btn-light">💰 Bounties</a
-              >
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg-4">
-          <div class="card">
-            <Image
-              class="card-img-top"
-              src={performanceImage}
-              alt="Performance"
-              style="width: 100%; height: 250px; object-fit: cover;"
-            />
-            <div class="card-body">
-              <h5 class="card-title">Performance</h5>
-              <a href="roadmap/performance/" class="btn btn-primary"
-                >Read more...</a
-              >
-              <a
-                href="https://github.com/maplibre/maplibre/issues/192"
-                class="btn btn-light">💰 Bounties</a
-              >
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <hr />
-      <h2>Under Consideration</h2>
-
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={blendingModesImage}
-            alt="Blending Modes"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">Blending Modes</h5>
-            <a href="roadmap/blending-modes/" class="btn btn-primary"
-              >Read more...</a
-            >
-            <a
-              href="https://github.com/maplibre/maplibre/issues/269"
-              class="btn btn-light">💰 Bounties</a
-            >
-          </div>
-        </div>
-      </div>
-
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={svgSymbolSourceImage}
-            alt="SVG Symbol Source"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">SVG Symbol Source</h5>
-            <a href="roadmap/svg-symbol-source/" class="btn btn-primary"
-              >Read more...</a
-            >
-            <a
-              href="https://github.com/maplibre/maplibre/issues/271"
-              class="btn btn-light">💰 Bounties</a
-            >
-          </div>
-        </div>
-      </div>
-
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={nonMercatorProjectionImage}
-            alt="Non-Mercator Projection"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">Non-Mercator Projection</h5>
-            <a href="roadmap/non-mercator-projection/" class="btn btn-primary"
-              >Read more...</a
-            >
-            <a
-              href="https://github.com/maplibre/maplibre/issues/272"
-              class="btn btn-light">💰 Bounties</a
-            >
-          </div>
-        </div>
-      </div>
-
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={lightweightRenderersImage}
-            alt="Lightweight Renderers"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">Lightweight Renderers</h5>
-            <a href="roadmap/lightweight-renderers/" class="btn btn-primary"
-              >Read more...</a
-            >
-            <a
-              href="https://github.com/maplibre/maplibre/issues/273"
-              class="btn btn-light">💰 Bounties</a
-            >
-          </div>
-        </div>
-      </div>
     </div>
+    ))}
 
-    <hr />
-    <h2>Released</h2>
-
-    <div class="row gy-4">
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={vulkanImage}
-            alt="Vulkan"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">Vulkan</h5>
-            <a href="roadmap/vulkan/" class="btn btn-primary">Read more...</a>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="row gy-4">
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={metalImage}
-            alt="Metal"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">Metal</h5>
-            <a href="roadmap/metal/" class="btn btn-primary">Read more...</a>
-          </div>
-        </div>
-      </div>
-
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={terrain3dImage}
-            alt="Terrain3D"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">Terrain3D</h5>
-            <a href="roadmap/terrain3d/" class="btn btn-primary">Read more...</a
-            >
-          </div>
-        </div>
-      </div>
-
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={communityGovernanceImage}
-            alt="Community & Governance"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">Community & Governance</h5>
-            <a href="roadmap/community-governance/" class="btn btn-primary"
-              >Read more...</a
-            >
-          </div>
-        </div>
-      </div>
-
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={iosAndroidReleaseImage}
-            alt="iOS and Android SDK Release"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">iOS and Android SDK Release</h5>
-            <a href="roadmap/ios-android-release/" class="btn btn-primary"
-              >Read more...</a
-            >
-          </div>
-        </div>
-      </div>
-
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={jsDocsImage}
-            alt="JS Documentation Website"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">JS Documentation Website</h5>
-            <a href="roadmap/js-docs/" class="btn btn-primary">Read more...</a>
-          </div>
-        </div>
-      </div>
-
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={typescriptImage}
-            alt="TypeScript"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">TypeScript</h5>
-            <a href="roadmap/typescript/" class="btn btn-primary"
-              >Read more...</a
-            >
-          </div>
-        </div>
-      </div>
-
-      <div class="col-lg-4">
-        <div class="card">
-          <Image
-            class="card-img-top"
-            src={projectWebsiteImage}
-            alt="Project Website"
-            style="width: 100%; height: 250px; object-fit: cover;"
-          />
-          <div class="card-body">
-            <h5 class="card-title">Project Website</h5>
-            <a href="roadmap/project-website/" class="btn btn-primary"
-              >Read more...</a
-            >
-          </div>
-        </div>
-      </div>
-    </div>
   </div>
 </Layout>

--- a/src/pages/roadmap/index.astro
+++ b/src/pages/roadmap/index.astro
@@ -36,7 +36,7 @@ title: "Roadmap";
     <div class="alert alert-success" role="alert">
       <b>Bounties:</b> Some projects on our Roadmap have Bounties, i.e., you can
       get paid for working on them.
-      <a class="btn btn-primary" href="step-by-step-bounties-guide"
+      <a class="btn btn-primary" href="roadmap/step-by-step-bounties-guide"
         >Read Step-by-Step Bounties Guide...</a
       >
     </div>

--- a/src/pages/roadmap/index.astro
+++ b/src/pages/roadmap/index.astro
@@ -5,7 +5,7 @@ import TitleHeader from "../../components/TitleHeader.astro";
 import { getCollection } from "astro:content";
 title: "Roadmap";
 
-const roadmapItems = (await getCollection("roadmapItems"));
+const roadmapItems = await getCollection("roadmapItems");
 
 const sections = [
   {
@@ -19,13 +19,11 @@ const sections = [
   {
     status: "released",
     title: "Released",
-  }
-]
-
+  },
+];
 ---
 
 <Layout title="Roadmap">
-
   <TitleHeader>Roadmap</TitleHeader>
   <style>
     .card {
@@ -47,43 +45,45 @@ const sections = [
 
     <hr />
 
-    {sections.map(section=>(
-      <>
-    <h2>{section.title}</h2>
-    <style>
-      .grid-container {
-      display: grid;
+    {
+      sections.map((section) => (
+        <>
+          <h2>{section.title}</h2>
+
+          <div
+            style="display: grid;
       grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
       gap: 1rem;
-      margin-bottom: 50px;
-      }
-    </style>
-    <div class="grid-container">
-      {roadmapItems.filter(item => item.data.status == section.status).map(item => {
-      return (
-      <div class="card">
-            <Image
-              class="card-img-top"
-              src={item.data.heroImage}
-              alt={item.data.title}
-              style="width: 100%; height: 250px; object-fit: cover;"
-            />
-            <div class="card-body">
-              <h5 class="card-title">{item.data.title}</h5>
-              <a href={`roadmap/${item.id}`} class="btn btn-primary"
-                >Read more...</a>
-              {item.data.bountyActive ? <a
-                href={item.data.bountyLink}
-                class="btn btn-light">💰 Bounties</a>
-              : null}
-            </div>
+      margin-bottom: 50px;"
+          >
+            {roadmapItems
+              .filter((item) => item.data.status == section.status)
+              .map((item) => {
+                return (
+                  <div class="card">
+                    <Image
+                      class="card-img-top"
+                      src={item.data.heroImage}
+                      alt={item.data.title}
+                      style="width: 100%; height: 250px; object-fit: cover;"
+                    />
+                    <div class="card-body">
+                      <h5 class="card-title">{item.data.title}</h5>
+                      <a href={`roadmap/${item.id}`} class="btn btn-primary">
+                        Read more...
+                      </a>
+                      {item.data.bountyActive ? (
+                        <a href={item.data.bountyLink} class="btn btn-light">
+                          💰 Bounties
+                        </a>
+                      ) : null}
+                    </div>
+                  </div>
+                );
+              })}
           </div>
-          )
-      })}
-
-    </div>
-    </>
-    ))}
-
+        </>
+      ))
+    }
   </div>
 </Layout>

--- a/src/pages/roadmap/index.astro
+++ b/src/pages/roadmap/index.astro
@@ -48,6 +48,7 @@ const sections = [
     <hr />
 
     {sections.map(section=>(
+      <>
     <h2>{section.title}</h2>
     <style>
       .grid-container {
@@ -81,6 +82,7 @@ const sections = [
       })}
 
     </div>
+    </>
     ))}
 
   </div>

--- a/src/pages/roadmap/step-by-step-bounties-guide/index.mdx
+++ b/src/pages/roadmap/step-by-step-bounties-guide/index.mdx
@@ -1,6 +1,13 @@
 ---
 title: Step-by-Step Bounties Guide
+layout: ../../../layouts/Layout.astro
 ---
+
+import TitleHeader from "../../../components/TitleHeader.astro";
+
+<TitleHeader>Step-by-Step Bounties Guide</TitleHeader>
+<div class="container">
+
 
 To get started doing bounties, follow this step-by-step guide.
 
@@ -35,3 +42,5 @@ Refer to the <a href="https://github.com/maplibre/maplibre/wiki/Bounty-System#bo
 ---
 
 If you have any questions around bounties and how you can start to contribute, feel free to reach out to us. Join our `#maplibre` Slack channel at https://slack.openstreetmap.us and ping someone from the team.
+
+</div>

--- a/src/pages/roadmap/step-by-step-bounties-guide/index.mdx
+++ b/src/pages/roadmap/step-by-step-bounties-guide/index.mdx
@@ -8,7 +8,6 @@ import TitleHeader from "../../../components/TitleHeader.astro";
 <TitleHeader>Step-by-Step Bounties Guide</TitleHeader>
 <div class="container">
 
-
 To get started doing bounties, follow this step-by-step guide.
 
 ## 1. Join the Developer Pool


### PR DESCRIPTION
This makes the roadmap items into a proper content collection, instead of hardcoding them on the overview page.

The roadmap items follow the schema:

```ts
const roadmapItems = defineCollection({
  loader: glob({ pattern: "**/*.mdx", base: "./src/content/roadmap" }),
  schema: ({ image }) =>
    z.object({
      title: z.string(),
      heroImage: image(),
      status: z.enum(["under-consideration", "in-progress", "released"]),
      bountyLink: z.optional(z.string()),
      bountyActive: z.optional(z.boolean()),
    }),
});
```

### It displays them with a CSS grid, responsively, from multiple to 1 element on mobile:


Before:

<img width="1526" alt="Screenshot 2024-12-15 at 22 01 21" src="https://github.com/user-attachments/assets/cb5632c0-1564-45da-b122-e59cb765759d" />


After

<img width="1473" alt="Screenshot 2024-12-15 at 22 01 29" src="https://github.com/user-attachments/assets/e2e08803-bd6a-49be-837d-41aaf6ff2fac" />



### Each entry has it's image optimized and inserted in the top:


Before:

<img width="1416" alt="Screenshot 2024-12-15 at 22 00 13" src="https://github.com/user-attachments/assets/03a4f3af-4a3e-43de-bafa-1439a1ed53ed" />


After

<img width="1382" alt="Screenshot 2024-12-15 at 22 00 23" src="https://github.com/user-attachments/assets/9ebd12bc-3a73-487d-8194-a15e341006d3" />

