### PR TITLE
Cleanup roadmap - bounty and released date

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -40,10 +40,12 @@ const roadmapItems = defineCollection({
       status: z.enum(["under-consideration", "in-progress", "released"]),
       bountyLink: z.optional(z.string()),
       bountyActive: z.optional(z.boolean()),
-      released: z.optional(z.string().transform((str) => {
-        const [month, year] = str.split(" ");
-        return new Date(`${month} 1, ${year}`);
-      })),
+      released: z.optional(
+        z.string().transform((str) => {
+          const [month, year] = str.split(" ");
+          return new Date(`${month} 1, ${year}`);
+        }),
+      ),
     }),
 });
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -40,6 +40,10 @@ const roadmapItems = defineCollection({
       status: z.enum(["under-consideration", "in-progress", "released"]),
       bountyLink: z.optional(z.string()),
       bountyActive: z.optional(z.boolean()),
+      released: z.optional(z.string().transform((str) => {
+        const [month, year] = str.split(" ");
+        return new Date(`${month} 1, ${year}`);
+      })),
     }),
 });
 

--- a/src/content/roadmap/blending-modes/index.mdx
+++ b/src/content/roadmap/blending-modes/index.mdx
@@ -14,8 +14,4 @@ Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/7/77/Hue_a
 
 GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/269
 
-Total Pre-Approved\* Budget: USD 5,000
-
-\*) The MapLibre Governing Board has given a pre-approval for this amount. If you require more funding to work on this Bounty Direction, please get in touch with the Governing Board. See also "Budget Increase" in the wiki: https://github.com/maplibre/maplibre/wiki/Bounty-System
-
 Find the Blending Modes discussion here: [#170](https://github.com/maplibre/maplibre/discussions/170).

--- a/src/content/roadmap/blending-modes/index.mdx
+++ b/src/content/roadmap/blending-modes/index.mdx
@@ -12,6 +12,4 @@ Goal:
 
 Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/7/77/Hue_alpha_falloff.svg">Wikipedia</a>
 
-GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/269
-
-Find the Blending Modes discussion here: [#170](https://github.com/maplibre/maplibre/discussions/170).
+Discussion Thread: [#170](https://github.com/maplibre/maplibre/discussions/170).

--- a/src/content/roadmap/community-governance/index.mdx
+++ b/src/content/roadmap/community-governance/index.mdx
@@ -2,10 +2,9 @@
 title: Community & Governance
 heroImage: "./image.png"
 status: released
+released: January 2021
 ---
 
 Kick-off the community & setup governance for the project
 
 https://www.maptiler.com/news/2021/01/mapbox-gl-open-source-fork/
-
-Released: January 2021

--- a/src/content/roadmap/documentation/index.mdx
+++ b/src/content/roadmap/documentation/index.mdx
@@ -10,5 +10,3 @@ Goals:
 
 - Write tutorials and getting started guides to help people migrate existing projects to MapLibre or help them with new map rendering projects.
 - Modernize documentation tooling to meet today's best practices and most widely adopted solutions.
-
-GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/191

--- a/src/content/roadmap/documentation/index.mdx
+++ b/src/content/roadmap/documentation/index.mdx
@@ -12,7 +12,3 @@ Goals:
 - Modernize documentation tooling to meet today's best practices and most widely adopted solutions.
 
 GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/191
-
-Total Pre-Approved\* Budget: USD 10,000
-
-\*) The MapLibre Governing Board has given a pre-approval for this amount. If you require more funding to work on this Bounty Direction, please get in touch with the Governing Board. See also "Budget Increase" in the wiki: https://github.com/maplibre/maplibre/wiki/Bounty-System

--- a/src/content/roadmap/globe-view/index.mdx
+++ b/src/content/roadmap/globe-view/index.mdx
@@ -14,7 +14,3 @@ Goals:
 GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/190
 
 Bounty Proposal Discussion: https://github.com/maplibre/maplibre/discussions/161
-
-Total Pre-Approved\* Budget: USD 20,000
-
-\*) The MapLibre Governing Board has given a pre-approval for this amount. If you require more funding to work on this Bounty Direction, please get in touch with the Governing Board. See also "Budget Increase" in the wiki: https://github.com/maplibre/maplibre/wiki/Bounty-System

--- a/src/content/roadmap/globe-view/index.mdx
+++ b/src/content/roadmap/globe-view/index.mdx
@@ -11,6 +11,4 @@ Goals:
 - Zoom out via Adaptive Composite Map Projection
 - Ability to show and interact with Globe (or alternative view on earth) when map is zoomed out - while reusing and loading the same Mercator vector tile and raster data - client side reprojection of the data - using Adaptive Composite Map Projection - where deeply zoomed you are in Mercator - but from certain zoom level up there is transition to another projection.
 
-GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/190
-
-Bounty Proposal Discussion: https://github.com/maplibre/maplibre/discussions/161
+Discussion Thread: https://github.com/maplibre/maplibre/discussions/161

--- a/src/content/roadmap/ios-android-release/index.mdx
+++ b/src/content/roadmap/ios-android-release/index.mdx
@@ -2,6 +2,7 @@
 title: iOS and Android SDK Release
 heroImage: "./image.png"
 status: released
+released: June 2021
 ---
 
 Public release of Android & iOS open-source SDK
@@ -9,5 +10,3 @@ Public release of Android & iOS open-source SDK
 https://www.maptiler.com/news/2021/06/maplibre-gl-native-open-source-mobile-sdk-for-android-and-ios/
 
 GitHub: https://github.com/maplibre/maplibre-native
-
-Released: June 2021

--- a/src/content/roadmap/js-docs/index.mdx
+++ b/src/content/roadmap/js-docs/index.mdx
@@ -2,10 +2,9 @@
 title: JS Documentation Website
 heroImage: "./image.png"
 status: released
+released: April 2021
 ---
 
 Publish examples and reference docs for GL JS: https://maplibre.org/maplibre-gl-js-docs/api/
 
 GitHub repository: https://github.com/maplibre/maplibre-gl-js-docs
-
-Released: April 2021

--- a/src/content/roadmap/lightweight-renderers/index.mdx
+++ b/src/content/roadmap/lightweight-renderers/index.mdx
@@ -14,8 +14,4 @@ Image Credit: <a href="https://openverse.org/image/9dc5204d-ef38-4921-9b56-4f225
 
 GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/273
 
-Total Pre-Approved\* Budget: USD 10,000
-
-\*) The MapLibre Governing Board has given a pre-approval for this amount. If you require more funding to work on this Bounty Direction, please get in touch with the Governing Board. See also "Budget Increase" in the wiki: https://github.com/maplibre/maplibre/wiki/Bounty-System
-
 Find the Lightweight Renderers discussion here: [#159](https://github.com/maplibre/maplibre/discussions/159).

--- a/src/content/roadmap/lightweight-renderers/index.mdx
+++ b/src/content/roadmap/lightweight-renderers/index.mdx
@@ -12,6 +12,4 @@ Goal:
 
 Image Credit: <a href="https://openverse.org/image/9dc5204d-ef38-4921-9b56-4f225741a2f3?q=renderer%20blocks">Openverse</a>
 
-GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/273
-
-Find the Lightweight Renderers discussion here: [#159](https://github.com/maplibre/maplibre/discussions/159).
+Discussion Thread: [#159](https://github.com/maplibre/maplibre/discussions/159).

--- a/src/content/roadmap/metal/index.mdx
+++ b/src/content/roadmap/metal/index.mdx
@@ -2,6 +2,7 @@
 title: Metal
 heroImage: "./image.png"
 status: released
+released: January 2024
 ---
 
 Implement a Metal graphics backend to ensure iOS in future releases is fully supported, as Apple is deprecating OpenGL.

--- a/src/content/roadmap/modernize-codebase/index.mdx
+++ b/src/content/roadmap/modernize-codebase/index.mdx
@@ -14,8 +14,4 @@ Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/thumb/6/65
 
 GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/270
 
-Total Pre-Approved\* Budget: USD 10,000
-
-\*) The MapLibre Governing Board has given a pre-approval for this amount. If you require more funding to work on this Bounty Direction, please get in touch with the Governing Board. See also "Budget Increase" in the wiki: https://github.com/maplibre/maplibre/wiki/Bounty-System
-
 Find the Modernize Codebase discussion here: [#185](https://github.com/maplibre/maplibre/discussions/185).

--- a/src/content/roadmap/modernize-codebase/index.mdx
+++ b/src/content/roadmap/modernize-codebase/index.mdx
@@ -12,6 +12,4 @@ Goal:
 
 Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/Globe_logo.svg/1142px-Globe_logo.svg.png">Wikipedia</a>
 
-GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/270
-
-Find the Modernize Codebase discussion here: [#185](https://github.com/maplibre/maplibre/discussions/185).
+Discussion Thread: [#185](https://github.com/maplibre/maplibre/discussions/185).

--- a/src/content/roadmap/non-mercator-projection/index.mdx
+++ b/src/content/roadmap/non-mercator-projection/index.mdx
@@ -16,8 +16,4 @@ Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/f/fa/Merca
 
 GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/272
 
-Total Pre-Approved\* Budget: USD 10,500
-
-\*) The MapLibre Governing Board has given a pre-approval for this amount. If you require more funding to work on this Bounty Direction, please get in touch with the Governing Board. See also "Budget Increase" in the wiki: https://github.com/maplibre/maplibre/wiki/Bounty-System
-
 Find the Custom Coordinate System/EPSG/Non-Mercator Projection discussion here: [#163](https://github.com/maplibre/maplibre/discussions/163).

--- a/src/content/roadmap/non-mercator-projection/index.mdx
+++ b/src/content/roadmap/non-mercator-projection/index.mdx
@@ -14,6 +14,4 @@ Goals:
 
 Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/f/fa/Mercator-proj.png">Wikipedia</a>
 
-GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/272
-
-Find the Custom Coordinate System/EPSG/Non-Mercator Projection discussion here: [#163](https://github.com/maplibre/maplibre/discussions/163).
+Discussion Thread: [#163](https://github.com/maplibre/maplibre/discussions/163).

--- a/src/content/roadmap/performance/index.mdx
+++ b/src/content/roadmap/performance/index.mdx
@@ -14,8 +14,6 @@ Goals:
 
 Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/3/33/Cartoon_space_rocket.png">Wikipedia</a>
 
-GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/192
-
 MapLibre Native: [Issues and Pull Requests](https://github.com/maplibre/maplibre-native/labels/%E2%9A%A1%20performance)
 
-Bounty Proposal Discussion: https://github.com/maplibre/maplibre/discussions/160
+Discussion Thread: https://github.com/maplibre/maplibre/discussions/160

--- a/src/content/roadmap/performance/index.mdx
+++ b/src/content/roadmap/performance/index.mdx
@@ -19,7 +19,3 @@ GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issu
 MapLibre Native: [Issues and Pull Requests](https://github.com/maplibre/maplibre-native/labels/%E2%9A%A1%20performance)
 
 Bounty Proposal Discussion: https://github.com/maplibre/maplibre/discussions/160
-
-Total Pre-Approved\* Budget: USD 10,000
-
-\*) The MapLibre Governing Board has given a pre-approval for this amount. If you require more funding to work on this Bounty Direction, please get in touch with the Governing Board. See also "Budget Increase" in the wiki: https://github.com/maplibre/maplibre/wiki/Bounty-System

--- a/src/content/roadmap/project-website/index.mdx
+++ b/src/content/roadmap/project-website/index.mdx
@@ -2,10 +2,9 @@
 title: Project Website
 heroImage: "./image.png"
 status: released
+released: June 2021
 ---
 
 Launch first version of https://maplibre.org
 
 GitHub repository: https://github.com/maplibre/maplibre.github.io
-
-Released: June 2021

--- a/src/content/roadmap/svg-symbol-source/index.mdx
+++ b/src/content/roadmap/svg-symbol-source/index.mdx
@@ -12,6 +12,4 @@ Goal:
 
 Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/SVG_logo.svg/768px-SVG_logo.svg.png">Wikipedia</a>
 
-GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/271
-
-Find the SVG Symbol Source discussion here: [#175](https://github.com/maplibre/maplibre/discussions/175) as well as the [MapLibre Style Spec](https://maplibre.org/maplibre-style-spec/layers/#symbol).
+Discussion Thread: [#175](https://github.com/maplibre/maplibre/discussions/175) as well as the [MapLibre Style Spec](https://maplibre.org/maplibre-style-spec/layers/#symbol).

--- a/src/content/roadmap/svg-symbol-source/index.mdx
+++ b/src/content/roadmap/svg-symbol-source/index.mdx
@@ -14,8 +14,4 @@ Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/thumb/0/02
 
 GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/271
 
-Total Pre-Approved\* Budget: USD 5,000
-
-\*) The MapLibre Governing Board has given a pre-approval for this amount. If you require more funding to work on this Bounty Direction, please get in touch with the Governing Board. See also "Budget Increase" in the wiki: https://github.com/maplibre/maplibre/wiki/Bounty-System
-
 Find the SVG Symbol Source discussion here: [#175](https://github.com/maplibre/maplibre/discussions/175) as well as the [MapLibre Style Spec](https://maplibre.org/maplibre-style-spec/layers/#symbol).

--- a/src/content/roadmap/terrain3d-improvements/index.mdx
+++ b/src/content/roadmap/terrain3d-improvements/index.mdx
@@ -12,6 +12,4 @@ Goals:
 - Visualization of the elevation from DEM (RGBA tiles) including drawing the tracks, labels and points.
 - Improvements related to 3d terrain rendering - improvements and bug-fixing in existing Web implementation, implementation in Native, documentation.
 
-GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/189
-
-Bounty Proposal Discussion: https://github.com/maplibre/maplibre/discussions/158
+Discussion Thread: https://github.com/maplibre/maplibre/discussions/158

--- a/src/content/roadmap/terrain3d-improvements/index.mdx
+++ b/src/content/roadmap/terrain3d-improvements/index.mdx
@@ -15,7 +15,3 @@ Goals:
 GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/189
 
 Bounty Proposal Discussion: https://github.com/maplibre/maplibre/discussions/158
-
-Total Pre-Approved\* Budget: USD 20,000
-
-\*) The MapLibre Governing Board has given a pre-approval for this amount. If you require more funding to work on this Bounty Direction, please get in touch with the Governing Board. See also "Budget Increase" in the wiki: https://github.com/maplibre/maplibre/wiki/Bounty-System

--- a/src/content/roadmap/terrain3d/index.mdx
+++ b/src/content/roadmap/terrain3d/index.mdx
@@ -2,6 +2,7 @@
 title: Terrain3D
 heroImage: "./image.png"
 status: released
+released: May 2022
 ---
 
 Visualization of the elevation from DEM (RGBA tiles) including drawing the tracks, labels and points.
@@ -9,5 +10,3 @@ Visualization of the elevation from DEM (RGBA tiles) including drawing the track
 Make a first release of Terrain3D in MapLibre GL JS.
 
 GitHub Pull Request: https://github.com/maplibre/maplibre-gl-js/pull/165
-
-Released: May 2022

--- a/src/content/roadmap/typescript/index.mdx
+++ b/src/content/roadmap/typescript/index.mdx
@@ -2,12 +2,9 @@
 title: TypeScript
 heroImage: "./image.jpeg"
 status: released
+released: September 2021
 ---
 
 Convert the entire library into TypeScript - add types & improve tests while remaining compatible on the API level.
 
-GitHub tracking issue: https://github.com/maplibre/maplibre-gl-js/issues/32
-
 GitHub Pull Request: https://github.com/maplibre/maplibre-gl-js/pull/209
-
-Released: September 2021

--- a/src/content/roadmap/vulkan/index.mdx
+++ b/src/content/roadmap/vulkan/index.mdx
@@ -2,6 +2,7 @@
 title: Vulkan
 heroImage: "./image.png"
 status: released
+released: December 2024
 ---
 
 [Vulkan](https://www.vulkan.org/) is a next-generation graphics API developed by the Khronos Group. In December 2024, MapLibre Android with Vulkan support was released. It is available as a separate package from Maven Central as [`org.maplibre.gl:android-sdk-vulkan`](https://central.sonatype.com/artifact/org.maplibre.gl/android-sdk-vulkan).

--- a/src/content/roadmap/writing-systems/index.mdx
+++ b/src/content/roadmap/writing-systems/index.mdx
@@ -17,7 +17,3 @@ GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issu
 Bounty Proposal Discussion: https://github.com/maplibre/maplibre/discussions/166
 
 [MapLibre Native Status](https://github.com/maplibre/maplibre-native/milestone/14)
-
-Total Pre-Approved\* Budget: USD 5,000
-
-\*) The MapLibre Governing Board has given a pre-approval for this amount. If you require more funding to work on this Bounty Direction, please get in touch with the Governing Board. See also "Budget Increase" in the wiki: https://github.com/maplibre/maplibre/wiki/Bounty-System

--- a/src/content/roadmap/writing-systems/index.mdx
+++ b/src/content/roadmap/writing-systems/index.mdx
@@ -12,8 +12,6 @@ Goals:
 
 Image Credit: <a href="https://en.wikipedia.org/wiki/Brahmic_scripts#/media/File:Different_scripts_of_different_languages_of_India.jpg">Wikipedia</a>
 
-GitHub Tracking Issue (💰 Bounties): https://github.com/maplibre/maplibre/issues/193
-
-Bounty Proposal Discussion: https://github.com/maplibre/maplibre/discussions/166
+Discussion Thread: https://github.com/maplibre/maplibre/discussions/166
 
 [MapLibre Native Status](https://github.com/maplibre/maplibre-native/milestone/14)

--- a/src/pages/roadmap/[...slug].astro
+++ b/src/pages/roadmap/[...slug].astro
@@ -37,16 +37,6 @@ function formatDate(dateString) {
           style="max-height:400px;height:auto;width:auto; max-width: 100%; border-radius: 10px; background-color: white; display: block; margin: 0 auto 20px auto;"
         />
 
-        {
-          roadmapItem.data.released ? (
-            <h2 style="margin: 20px 0; text-align:center;">
-              Released: {formatDate(roadmapItem.data.released)}
-            </h2>
-          ) : (
-            ""
-          )
-        }
-
         <Content />
 
         {
@@ -55,6 +45,16 @@ function formatDate(dateString) {
               💰 Bounties
             </a>
           ) : null
+        }
+
+        {
+          roadmapItem.data.released ? (
+            <p style="font-weight: bold;">
+              Released: {formatDate(roadmapItem.data.released)}
+            </p>
+          ) : (
+            ""
+          )
         }
       </div>
     </div>

--- a/src/pages/roadmap/[...slug].astro
+++ b/src/pages/roadmap/[...slug].astro
@@ -17,6 +17,12 @@ type Props = CollectionEntry<"roadmapItems">;
 const roadmapItem = Astro.props;
 const { Content } = await render(roadmapItem);
 import { Image } from "astro:assets";
+
+function formatDate(dateString) {
+    const date = new Date(dateString);
+    const options = { year: 'numeric', month: 'long' };
+    return date.toLocaleDateString('en-US', options);
+  }
 ---
 
 <Layout title={roadmapItem.data.title}>
@@ -28,9 +34,20 @@ import { Image } from "astro:assets";
           format="png"
           alt={roadmapItem.data.title}
           src={roadmapItem.data.heroImage}
-          style="max-width:600px;height:auto;width:100%; border-radius: 10px; background-color: white; display: block; margin: 0 auto 20px auto;"
+          style="max-height:400px;height:auto;width:auto; max-width: 100%; border-radius: 10px; background-color: white; display: block; margin: 0 auto 20px auto;"
         />
+
+        {roadmapItem.data.released ? <h2 style="margin: 20px 0; text-align:center;">Released: {formatDate(roadmapItem.data.released)}</h2> : ""}
+
         <Content />
+
+        {roadmapItem.data.bountyActive ? (
+          <a href={roadmapItem.data.bountyLink} class="btn btn-light">
+            💰 Bounties
+          </a>
+        ) : null}
+
+        
       </div>
     </div>
   </div>

--- a/src/pages/roadmap/[...slug].astro
+++ b/src/pages/roadmap/[...slug].astro
@@ -19,10 +19,10 @@ const { Content } = await render(roadmapItem);
 import { Image } from "astro:assets";
 
 function formatDate(dateString) {
-    const date = new Date(dateString);
-    const options = { year: 'numeric', month: 'long' };
-    return date.toLocaleDateString('en-US', options);
-  }
+  const date = new Date(dateString);
+  const options = { year: "numeric", month: "long" };
+  return date.toLocaleDateString("en-US", options);
+}
 ---
 
 <Layout title={roadmapItem.data.title}>
@@ -37,17 +37,25 @@ function formatDate(dateString) {
           style="max-height:400px;height:auto;width:auto; max-width: 100%; border-radius: 10px; background-color: white; display: block; margin: 0 auto 20px auto;"
         />
 
-        {roadmapItem.data.released ? <h2 style="margin: 20px 0; text-align:center;">Released: {formatDate(roadmapItem.data.released)}</h2> : ""}
+        {
+          roadmapItem.data.released ? (
+            <h2 style="margin: 20px 0; text-align:center;">
+              Released: {formatDate(roadmapItem.data.released)}
+            </h2>
+          ) : (
+            ""
+          )
+        }
 
         <Content />
 
-        {roadmapItem.data.bountyActive ? (
-          <a href={roadmapItem.data.bountyLink} class="btn btn-light">
-            💰 Bounties
-          </a>
-        ) : null}
-
-        
+        {
+          roadmapItem.data.bountyActive ? (
+            <a href={roadmapItem.data.bountyLink} class="btn btn-light">
+              💰 Bounties
+            </a>
+          ) : null
+        }
       </div>
     </div>
   </div>

--- a/src/pages/roadmap/index.astro
+++ b/src/pages/roadmap/index.astro
@@ -35,16 +35,8 @@ const sections = [
     }
   </style>
   <div class="container">
-    <div class="alert alert-success" role="alert">
-      <b>Bounties:</b> Some projects on our Roadmap have Bounties, i.e., you can
-      get paid for working on them.
-      <a class="btn btn-primary" href="roadmap/step-by-step-bounties-guide"
-        >Read Step-by-Step Bounties Guide...</a
-      >
-    </div>
-
-    <hr />
-
+    
+    
     {
       sections.map((section) => (
         <>
@@ -72,11 +64,6 @@ const sections = [
                       <a href={`roadmap/${item.id}`} class="btn btn-primary">
                         Read more...
                       </a>
-                      {item.data.bountyActive ? (
-                        <a href={item.data.bountyLink} class="btn btn-light">
-                          💰 Bounties
-                        </a>
-                      ) : null}
                     </div>
                   </div>
                 );

--- a/src/pages/roadmap/index.astro
+++ b/src/pages/roadmap/index.astro
@@ -21,6 +21,12 @@ const sections = [
     title: "Released",
   },
 ];
+
+function formatDate(dateString) {
+    const date = new Date(dateString);
+    const options = { year: 'numeric', month: 'long' };
+    return date.toLocaleDateString('en-US', options);
+  }
 ---
 
 <Layout title="Roadmap">
@@ -50,6 +56,7 @@ const sections = [
           >
             {roadmapItems
               .filter((item) => item.data.status == section.status)
+              .sort((a, b) => b.data.released - a.data.released)
               .map((item) => {
                 return (
                   <div class="card">
@@ -64,6 +71,7 @@ const sections = [
                       <a href={`roadmap/${item.id}`} class="btn btn-primary">
                         Read more...
                       </a>
+                      {item.data.released ? <p style="margin: 10px 0 0 0;">Released: {formatDate(item.data.released)}</p> : ""}
                     </div>
                   </div>
                 );

--- a/src/pages/roadmap/index.astro
+++ b/src/pages/roadmap/index.astro
@@ -23,10 +23,10 @@ const sections = [
 ];
 
 function formatDate(dateString) {
-    const date = new Date(dateString);
-    const options = { year: 'numeric', month: 'long' };
-    return date.toLocaleDateString('en-US', options);
-  }
+  const date = new Date(dateString);
+  const options = { year: "numeric", month: "long" };
+  return date.toLocaleDateString("en-US", options);
+}
 ---
 
 <Layout title="Roadmap">
@@ -41,8 +41,6 @@ function formatDate(dateString) {
     }
   </style>
   <div class="container">
-    
-    
     {
       sections.map((section) => (
         <>
@@ -71,7 +69,13 @@ function formatDate(dateString) {
                       <a href={`roadmap/${item.id}`} class="btn btn-primary">
                         Read more...
                       </a>
-                      {item.data.released ? <p style="margin: 10px 0 0 0;">Released: {formatDate(item.data.released)}</p> : ""}
+                      {item.data.released ? (
+                        <p style="margin: 10px 0 0 0;">
+                          Released: {formatDate(item.data.released)}
+                        </p>
+                      ) : (
+                        ""
+                      )}
                     </div>
                   </div>
                 );


### PR DESCRIPTION
I find the roadmap is drowning a bit in bounty info. All the info is repeated inside each roadmap items.

Before:
<img width="1360" alt="Screenshot 2024-12-16 at 02 27 08" src="https://github.com/user-attachments/assets/0514210b-fbd8-484b-a50a-234c6fd7ffc4" />

After
<img width="1380" alt="Screenshot 2024-12-16 at 02 26 13" src="https://github.com/user-attachments/assets/4a7a24bc-2584-41e9-acda-0e53ed9e9d5c" />

For the released date I've also added that to the content collection, so released features are sorted

Before:
<img width="1365" alt="Screenshot 2024-12-16 at 02 54 44" src="https://github.com/user-attachments/assets/fc369cd5-7919-480a-ab5e-d4163eddb6da" />


After:
<img width="1336" alt="Screenshot 2024-12-16 at 02 52 00" src="https://github.com/user-attachments/assets/68d74c85-6d14-4f25-aaf2-f73c95d1df49" />



Removing redundant information, the view for single entries are updated:

Before
<img width="771" alt="Screenshot 2024-12-16 at 02 55 36" src="https://github.com/user-attachments/assets/9d5b8e8c-3dfb-4af8-b853-58ed1f4283f4" />

After
<img width="799" alt="Screenshot 2024-12-16 at 02 55 44" src="https://github.com/user-attachments/assets/aa984b66-d0bd-4f86-a533-26563f66fb08" />
