### PR TITLE
Update monthly meeting times

### DIFF
--- a/src/content/news/2025-02-03-maplibre-newsletter-january-2025/index.mdx
+++ b/src/content/news/2025-02-03-maplibre-newsletter-january-2025/index.mdx
@@ -98,13 +98,10 @@ Despite announcing v0.15 Martin release last month, we hit a last second testing
 
 ## Monthly meetings
 
-We will hold our monthly meetings on the second Wednesday of each month. However, for this month only, the _**MapLibre GL JS meeting will be held on February 19**_ instead of the usual second Wednesday. All other meetings will continue as scheduled.
-There will be an additional session on the last Wednesday to better accommodate participants in Asia time zones.
+We will hold our monthly meetings on the second Wednesday of each month. However, for this month only, _**all our meetings will be held on February 19**_ instead of the usual second Wednesday. There will be an additional session on the last Wednesday to better accommodate participants in Asia time zones.
 
-#### Second Wednesday Meetings (Feb 12, 2025)
-
-- MapLibre Navigation: 5:00–6:00 PM UTC
-- MapLibre Native: 6:00–7:00 PM UTC
+- MapLibre Navigation: **Feb 19, 2025 5:00–6:00 PM UTC**
+- MapLibre Native: **Feb 19, 2025 6:00–7:00 PM UTC**
 - MapLibre GL JS: **Feb 19, 2025 - 7:00–8:00 PM UTC**
 
 #### Last Wednesday Meeting (Asia Friendly)

--- a/src/content/news/2025-02-03-maplibre-newsletter-january-2025/index.mdx
+++ b/src/content/news/2025-02-03-maplibre-newsletter-january-2025/index.mdx
@@ -108,6 +108,6 @@ We will hold our monthly meetings on the second Wednesday of each month. However
 
 - Feb 26, 2025 - 9:00–10:00 AM UTC
 
-View meeting times in your time zone: https://notime.zone/OIJXZR9vM3EeY.
+View meeting times in your time zone: https://notime.zone/OILeS6ABXai72.
 
 All calls are open to everyone. Zoom links can be found in our MapLibre Slack. If you’re not a member, request an invite at [OpenStreetMap US Slack community](https://slack.openstreetmap.us/). We look forward to seeing you!


### PR DESCRIPTION
Per chat with maintainers, it is best to retain all the meetings on the same day. So we are pushing it all to 19 Feb instead of 12 Feb. This PR updates the details in the newsletter and the timings in the notimezone link.