### PR TITLE
fix(community-map): replace href to github property

### DIFF
--- a/src/components/CommunityMap.tsx
+++ b/src/components/CommunityMap.tsx
@@ -58,7 +58,7 @@ export const CommunityMap = (props: any) => {
       img.src = `community/${person.github}.png`;
 
       const anchor = document.createElement("a");
-      anchor.href = `https://github.com/${person.href}`;
+      anchor.href = `https://github.com/${person.github}`;
       anchor.title = person.github;
 
       anchor.append(img);


### PR DESCRIPTION
# Description

This PR addresses an issue with the Community Map functionality, which was failing due to an undefined return when attempting to access an invalid property href from the community.json file.

Key Changes:

- Replaced the incorrect property `href` with the correct property `github` to ensure the correct URL to GitHub member accounts.