### PR TITLE
feat: enable view-transitions (and prefetching)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,5 +7,6 @@ export default defineConfig({
   base: "",
   integrations: [mdx(), solidJs()],
   output: "static",
+  prefetch: true,
   site: "https://maplibre.org/",
 });

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,7 +4,7 @@ import Footer from "../components/Footer.astro";
 import Nav from "../components/Nav.astro";
 import { SITE_TITLE } from "../constants";
 const { title, description } = Astro.props;
-import { ClientRouter } from "astro:transitions";
+import { ClientRouter, fade } from "astro:transitions";
 ---
 
 <!doctype html>
@@ -82,7 +82,7 @@ import { ClientRouter } from "astro:transitions";
       {title ? `${title} | ${SITE_TITLE}` : SITE_TITLE}
     </title>
   </head>
-  <body>
+  <body transition:animate={fade({ duration: "0.2s" })}>
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,7 +4,7 @@ import Footer from "../components/Footer.astro";
 import Nav from "../components/Nav.astro";
 import { SITE_TITLE } from "../constants";
 const { title, description } = Astro.props;
-// import { ClientRouter } from 'astro:transitions';
+import { ClientRouter } from 'astro:transitions';
 ---
 
 <!doctype html>
@@ -19,7 +19,7 @@ const { title, description } = Astro.props;
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="author" content="MapLibre" />
     <meta name="description" content={description} />
-    <!-- <ClientRouter /> -->
+    <ClientRouter />
 
     <meta
       property="og:image"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,7 +4,7 @@ import Footer from "../components/Footer.astro";
 import Nav from "../components/Nav.astro";
 import { SITE_TITLE } from "../constants";
 const { title, description } = Astro.props;
-import { ClientRouter } from 'astro:transitions';
+import { ClientRouter } from "astro:transitions";
 ---
 
 <!doctype html>


### PR DESCRIPTION
@birkskyum you seem to have commented this one out.

I think that view transitions ([docs on this feature](https://docs.astro.build/en/guides/view-transitions/)) seem to be a better experience.

| before | after |
|--------|--------|
| ![Recording 2025-04-21 at 23 23 48](https://github.com/user-attachments/assets/f0e128ee-02d6-4ec6-94aa-4e081b7d4217)| ![after](https://github.com/user-attachments/assets/e671bf53-3e5d-4c91-b9dc-aca2cb023497) |

I added the prefetching part mostly to make this apparent to other devs.
Using the view transitions automatically enables this.

After experimenting with a few options, I think that the default (fading) works nicely for our site compared to the other build-in animation (slide).
If one of you has strong oppinions on this, I am happy to add them and post screencaps.