### PR TITLE
update maplibre-compose urls

### DIFF
--- a/src/content/news/2025-01-05-maplibre-newsletter-december-2024/index.mdx
+++ b/src/content/news/2025-01-05-maplibre-newsletter-december-2024/index.mdx
@@ -24,14 +24,14 @@ Let’s dive in!
 
 ### Kotlin Multiplatform
 
-Exciting news for developers interested in [**Kotlin Multiplatform**](https://kotlinlang.org/docs/multiplatform.html): [Sargun Vohra](https://github.com/sargunv), with input from [Tobias Zwick](https://github.com/westnordost), has released [MapLibre for Compose](https://github.com/sargunv/maplibre-compose#maplibre-for-compose)!
+Exciting news for developers interested in [**Kotlin Multiplatform**](https://kotlinlang.org/docs/multiplatform.html): [Sargun Vohra](https://github.com/sargunv), with input from [Tobias Zwick](https://github.com/westnordost), has released [MapLibre for Compose](https://github.com/maplibre/maplibre-compose#maplibre-for-compose)!
 
 The library integrates MapLibre iOS and MapLibre Android and is open to contributions. Experiments that add desktop support as well as support for the web (by intergrating with MapLibre GL JS) are underway.
 
 Originally released late November, the library is now at v0.4.0. Get started here:
 
-- 📂 Repository: [GitHub Repo](https://github.com/sargunv/maplibre-compose)
-- 📖 Documentation: [Explore Docs](https://sargunv.github.io/maplibre-compose/)
+- 📂 Repository: [GitHub Repo](https://github.com/maplibre/maplibre-compose)
+- 📖 Documentation: [Explore Docs](https://maplibre.org/maplibre-compose/)
 
 Here’s a sneak peek of MapLibre for Compose in action:
 


### PR DESCRIPTION
related: https://github.com/maplibre/maplibre/issues/441

the old docs url no longer works because GH does not redirect Pages urls