### PR TITLE
fix the icon of marc being not specified

### DIFF
--- a/src/content/bio/marc/index.md
+++ b/src/content/bio/marc/index.md
@@ -5,10 +5,9 @@ handle: marc
 
 <div class="text-center mb-5">
     <img
-        src=""
+        src="https://avatars.githubusercontent.com/u/53413200?v=4"
         width="150"
         class="rounded-circle mt-3"
-        onerror="this.onerror=null; this.src='https://via.placeholder.com/150?text=No+Image';"
     />
     <h3 class="m-3">Marc Wilson</h3>
     <p>Graphics Engineer</p>

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -81,10 +81,9 @@ import Layout from "../../layouts/Layout.astro";
             <div class="text-center person">
               <a href="about/marc">
                 <img
-                  src=""
+                  src="https://avatars.githubusercontent.com/u/53413200?v=4"
                   width="150"
                   class="rounded-circle mt-3 border border-white"
-                  onerror="this.onerror=null; this.src='https://via.placeholder.com/150?text=No+Image';"
                 />
                 <h3 class="m-3">Marc Wilson</h3>
                 Graphics Engineer


### PR DESCRIPTION
this PR fixes the icon of @mwilsnd not working. placeholder.com does not exist, which is why this looks so broken ^^

![image](https://github.com/user-attachments/assets/3eeae286-d01f-45bf-9e5d-8a5cc03de2bc)

I took your image from github, not linkedin.