### PR TITLE
Add frontmatter to template

### DIFF
--- a/.github/ISSUE_TEMPLATE/newsletter.md
+++ b/.github/ISSUE_TEMPLATE/newsletter.md
@@ -1,8 +1,16 @@
+---
+name: Newsletter Input Draft
+about: Use this template to invite community inputs for MapLibre newsletter.
+title: "[Newsletter]: "
+labels: newsletter
+assignees: ""
+---
+
 Gathering updates for the MMM edition of the MapLibre newsletter! If you have project updates, community event announcements, or other highlights you’d like to share, please comment below.
 
-🕕 Submission Deadline: DD-MMM XX UTC
-🎫 Previous issue: https://github.com/maplibre/maplibre.github.io/issues/xxx
-🗒 Previous newsletters: https://maplibre.org/categories/newsletter/
+🕕 Submission Deadline: DD-MMM XX UTC </br>
+🎫 Previous issue: https://github.com/maplibre/maplibre.github.io/issues/xxx </br>
+🗒 Previous newsletters: https://maplibre.org/categories/newsletter/ </br>
 
 ## What to Submit
 


### PR DESCRIPTION
In spite of :
* moving the template to a dedicated folder within `.github` and
* adding a config.yml file,

 issue creation does not list the template during issue creation. Looks like it is mandatory to include the frontmatter within the template so that the content is not ignored.