### PR TITLE
Include a list of FOSS4G talks to newsletter

### DIFF
--- a/src/content/news/2025-07-02-maplibre-newsletter-june-2025/index.mdx
+++ b/src/content/news/2025-07-02-maplibre-newsletter-june-2025/index.mdx
@@ -208,6 +208,88 @@ The MapLibre team will be at [FOSS4G Europe](https://2025.europe.foss4g.org/) th
 🗓️ Dates: July 14-20, 2025 <br></br>
 📍 Location: [Mostar, Bosnia-Herzegovina](https://www.openstreetmap.org/relation/8480923)
 
+<div style="overflow-x: auto;">
+  <table style="width: 100%; border-collapse: collapse; font-size: 0.95rem; min-width: 600px;">
+    <thead>
+      <tr>
+        <th style="border-bottom: 1px solid #ccc; text-align: left; padding: 8px 12px;">
+          Talk/Workshop
+        </th>
+        <th style="border-bottom: 1px solid #ccc; text-align: left; padding: 8px 12px; min-width: 90px;">
+          Date
+        </th>
+        <th style="border-bottom: 1px solid #ccc; text-align: left; padding: 8px 12px;">
+          Time (Europe/Sarajevo)
+        </th>
+        <th style="border-bottom: 1px solid #ccc; text-align: left; padding: 8px 12px;">
+          Location
+        </th>
+        <th style="border-bottom: 1px solid #ccc; text-align: left; padding: 8px 12px;">
+          Presenter
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td style="padding: 8px 12px;">
+          <a href="https://talks.osgeo.org/foss4g-europe-2025-workshops/talk/M9888F/">
+            Tile serving with MapLibre/Martin/Planetiler — base and overlays
+            (Workshop)
+          </a>
+        </td>
+        <td style="padding: 8px 12px; min-width: 90px;">Jul 14</td>
+        <td style="padding: 8px 12px;">14:00–18:00</td>
+        <td style="padding: 8px 12px;">PL14</td>
+        <td style="padding: 8px 12px;">Yuri Astrakhan</td>
+      </tr>
+      <tr>
+        <td style="padding: 8px 12px;">
+          <a href="https://talks.osgeo.org/foss4g-europe-2025/talk/G7WVWY/">
+            MapLibre projects, in one status update
+          </a>
+        </td>
+        <td style="padding: 8px 12px; min-width: 90px;">Jul 16</td>
+        <td style="padding: 8px 12px;">13:30–14:00</td>
+        <td style="padding: 8px 12px;">EL11</td>
+        <td style="padding: 8px 12px;">Yuri Astrakhan</td>
+      </tr>
+      <tr>
+        <td style="padding: 8px 12px;">
+          <a href="https://talks.osgeo.org/foss4g-europe-2025/talk/989LUY/">
+            Serverless Rasters on the Web: The MapLibre COG Protocol extension
+          </a>
+        </td>
+        <td style="padding: 8px 12px; min-width: 90px;">Jul 16</td>
+        <td style="padding: 8px 12px;">16:00–16:30</td>
+        <td style="padding: 8px 12px;">CA01</td>
+        <td style="padding: 8px 12px;">Marti Pericay, Oscar Fonts</td>
+      </tr>
+      <tr>
+        <td style="padding: 8px 12px;">
+          <a href="https://talks.osgeo.org/foss4g-europe-2025/talk/WMYSPU/">
+            Scaling FOSS Development and Decisionmaking feat MapLibre Native
+          </a>
+        </td>
+        <td style="padding: 8px 12px; min-width: 90px;">Jul 17</td>
+        <td style="padding: 8px 12px;">11:30–12:00</td>
+        <td style="padding: 8px 12px;">SA02</td>
+        <td style="padding: 8px 12px;">Bart Louwers</td>
+      </tr>
+      <tr>
+        <td style="padding: 8px 12px;">
+          <a href="https://talks.osgeo.org/foss4g-europe-2025/talk/UTUW8Z/">
+            maplibre-gl-terradraw — new drawing plugin for maplibre-gl-js
+          </a>
+        </td>
+        <td style="padding: 8px 12px; min-width: 90px;">Jul 18</td>
+        <td style="padding: 8px 12px;">14:30–15:00</td>
+        <td style="padding: 8px 12px;">CA01</td>
+        <td style="padding: 8px 12px;">Jin Igarashi</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
 ## 🗓️ Monthly meetings
 
 We continue our regular community calls on the _**second Wednesday**_ of each month, with an additional session on the last Wednesday to better accommodate Asia/Oceania time zones.


### PR DESCRIPTION
This PR includes a list of MapLibre's talks and workshops at this year's FOSS4G Europe conference. Using a HTML table for better formatting flexibility.