### PR TITLE
feat(authors): add an author page for myself

### DIFF
--- a/src/content/authors/frank/index.md
+++ b/src/content/authors/frank/index.md
@@ -3,3 +3,24 @@ title: Frank Elsinga
 github: CommanderStorm
 handle: frank
 ---
+
+<div class="text-center mb-5">
+    <img
+        src="https://avatars.githubusercontent.com/u/26258709?v=4"
+        width="150"
+        class="rounded-circle mt-3"
+    />
+    <h3 class="m-3">Frank Elsinga</h3>
+    <p><a href="https://github.com/CommanderStrom">GitHub</a> · <a href="https://osmus.slack.com/team/U07SNL36BN3">Slack</a> · <a href="https://www.linkedin.com/in/frankelsinga/">LinkedIn</a>
+</div>
+
+Hi, my name is Frank. 👋
+
+I am the founder of the student club [OpenSource @ TUM e.V.](https://tum.dev/).
+As part of this student club, I build an Roomfinder[^1].
+Originally, said Roomfinder ran on Mapbox - Until, after two weeks, our credits ran out because we did not anticipate the growth, and being a young student club did not have the budget to just eat the costs.
+We have been with [MapLibre](https://maplibre.org) and the wider [FOSS4G-movement](https://foss4g.org/) ever since and are delighted with this decision.
+
+At MapLibre I maintain the (blazingly fast 🦀) [Martin Tileserver](https://github.com/maplibre/martin) and the maplibre-native rust wrapper [`maplibre-native-rs`](https://github.com/maplibre/maplibre-native-rs).
+
+[^1]: Our university has 40k rooms and really weird geometries. Architects naming rooms after the 7 (!) cardinal directions or colors, putting stairs in random places or similar is not very understandable for our students/staff.


### PR DESCRIPTION
I think this page looks a bit empty otherwise and since It is on the first page of google, I would like to have at least my github linked, if possible also the rest of the text (since it explains a bit of the "Why"):

<img width="1456" height="909" alt="image" src="https://github.com/user-attachments/assets/956bddaa-a8cb-4b6f-a4f4-be75747861db" />
