### PR TITLE
add maplibre spec link

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -338,6 +338,11 @@ import { SITE_DESCRIPTION } from "../constants";
                 >
               </li>
               <li>
+                <a href="https://maplibre.org/maplibre-tile-spec"
+                  >MapLibre Tile Specification</a
+                >
+              </li>
+              <li>
                 <a href="https://github.com/maplibre"
                   >All MapLibre GitHub repositories</a
                 >


### PR DESCRIPTION
TODO: would be great to introduce a proper tile spec section, just like other primary projects