### PR TITLE
white background for roadmap entries

### DIFF
--- a/src/pages/roadmap/[project]/index.astro
+++ b/src/pages/roadmap/[project]/index.astro
@@ -126,7 +126,7 @@ function formatDate(dateValue) {
         On current chrome versions, an 1px border appears in the corners of the image.
         The corner-border looks very ugly
         */
-        background-color: #1e3150;
+        background-color: white;
       }
     }
 


### PR DESCRIPTION
A background color was set wrong, making i.e. vulkan look bit odd

Before
<img width="327" height="420" alt="Screenshot 2025-10-05 at 15 16 24" src="https://github.com/user-attachments/assets/4ede0fcb-fa5e-4668-89d6-e3d18970c368" />

After
<img width="336" height="440" alt="Screenshot 2025-10-05 at 15 16 12" src="https://github.com/user-attachments/assets/5dbe04cf-c61f-486a-a33b-1effe9be29e8" />
