### PR TITLE
feat: Make roadmap project field an array

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -31,7 +31,8 @@ const roadmapItems = defineCollection({
       heroImage: image(),
       heroImageFit: z.optional(z.enum(["fill", "contain", "cover"])),
       status: z.enum(["under-consideration", "in-progress", "released"]),
-      project: z
+      project: z.array(
+        z
         .enum([
           "general",
           "maplibre-native",
@@ -39,7 +40,9 @@ const roadmapItems = defineCollection({
           "maplibre-tile-format",
           "martin-tile-server",
         ])
-        .default("general"),
+        .default("general")
+      )
+      .nonempty(),
       bountyLink: z.optional(z.string()),
       bountyActive: z.optional(z.boolean()),
       released: z.optional(

--- a/src/content/roadmap/general/community-governance/index.mdx
+++ b/src/content/roadmap/general/community-governance/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Community & Governance
 heroImage: "./image.png"
-project: general
+project: [ general ]
 status: released
 released: January 2021
 ---

--- a/src/content/roadmap/general/project-website/index.mdx
+++ b/src/content/roadmap/general/project-website/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Project Website
 heroImage: "./image.png"
-project: general
+project: [ general ]
 status: released
 released: June 2021
 ---

--- a/src/content/roadmap/maplibre-gl-js/blending-modes/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/blending-modes/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Blending Modes
 heroImage: "./image.png"
-project: maplibre-gl-js
+project: [ maplibre-gl-js ]
 status: under-consideration
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/269

--- a/src/content/roadmap/maplibre-gl-js/globe-view/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/globe-view/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Globe View
 heroImage: "./image.png"
-project: maplibre-gl-js
+project: [ maplibre-gl-js ]
 status: released
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/190

--- a/src/content/roadmap/maplibre-gl-js/js-docs/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/js-docs/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: JS Documentation Website
 heroImage: "./image.png"
-project: maplibre-gl-js
+project: [ maplibre-gl-js ]
 status: released
 released: April 2021
 ---

--- a/src/content/roadmap/maplibre-gl-js/luma-gl-refactor/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/luma-gl-refactor/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Refactor Rendering to luma.gl
 heroImage: "./luma.png"
-project: maplibre-gl-js
+project: [ maplibre-gl-js ]
 status: in-progress
 ---
 

--- a/src/content/roadmap/maplibre-gl-js/non-mercator-projection/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/non-mercator-projection/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Non-Mercator Projection
 heroImage: "./image.png"
-project: maplibre-gl-js
+project: [ maplibre-gl-js ]
 status: under-consideration
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/272

--- a/src/content/roadmap/maplibre-gl-js/svg-symbol-source/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/svg-symbol-source/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: SVG Symbol Source
 heroImage: "./image.png"
-project: maplibre-gl-js
+project: [ maplibre-gl-js ]
 status: under-consideration
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/271

--- a/src/content/roadmap/maplibre-gl-js/terrain3d/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/terrain3d/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Terrain3D
 heroImage: "./image.png"
-project: maplibre-gl-js
+project: [ maplibre-gl-js ]
 status: released
 released: May 2022
 ---

--- a/src/content/roadmap/maplibre-gl-js/typescript/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/typescript/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: TypeScript
 heroImage: "./image.jpeg"
-project: maplibre-gl-js
+project: [ maplibre-gl-js ]
 status: released
 released: September 2021
 ---

--- a/src/content/roadmap/maplibre-gl-js/writing-systems/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/writing-systems/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Writing Systems
 heroImage: "./image.png"
-project: maplibre-gl-js
+project: [ maplibre-gl-js ]
 status: under-consideration
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/193

--- a/src/content/roadmap/maplibre-native/globe-view/index.mdx
+++ b/src/content/roadmap/maplibre-native/globe-view/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Globe View
 heroImage: "./image.png"
-project: maplibre-native
+project: [ maplibre-native ]
 status: under-consideration
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/190

--- a/src/content/roadmap/maplibre-native/ios-android-release/index.mdx
+++ b/src/content/roadmap/maplibre-native/ios-android-release/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: iOS and Android SDK Release
 heroImage: "./image.png"
-project: maplibre-native
+project: [ maplibre-native ]
 status: released
 released: June 2021
 ---

--- a/src/content/roadmap/maplibre-native/metal/index.mdx
+++ b/src/content/roadmap/maplibre-native/metal/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Metal
 heroImage: "./image.png"
-project: maplibre-native
+project: [ maplibre-native ]
 status: released
 released: January 2024
 ---

--- a/src/content/roadmap/maplibre-native/non-mercator-projection/index.mdx
+++ b/src/content/roadmap/maplibre-native/non-mercator-projection/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Non-Mercator Projection
 heroImage: "./image.png"
-project: maplibre-native
+project: [ maplibre-native ]
 status: under-consideration
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/272

--- a/src/content/roadmap/maplibre-native/terrain3d/index.mdx
+++ b/src/content/roadmap/maplibre-native/terrain3d/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Terrain3D
 heroImage: "./image.png"
-project: maplibre-native
+project: [ maplibre-native ]
 status: under-consideration
 ---
 

--- a/src/content/roadmap/maplibre-native/vulkan/index.mdx
+++ b/src/content/roadmap/maplibre-native/vulkan/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Vulkan
 heroImage: "./image.png"
-project: maplibre-native
+project: [ maplibre-native ]
 status: released
 released: December 2024
 ---

--- a/src/content/roadmap/maplibre-native/webgpu/index.mdx
+++ b/src/content/roadmap/maplibre-native/webgpu/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: WebGPU Renderer
 heroImage: "./webgpu.svg"
-project: maplibre-native
+project: [ maplibre-native ]
 status: in-progress
 ---
 

--- a/src/content/roadmap/maplibre-native/writing-systems/index.mdx
+++ b/src/content/roadmap/maplibre-native/writing-systems/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Writing Systems
 heroImage: "./image.png"
-project: maplibre-native
+project: [ maplibre-native ]
 status: released
 bountyActive: true
 bountyLink: https://github.com/maplibre/maplibre/issues/193

--- a/src/content/roadmap/maplibre-tile-format/maplibre-tile-format/index.mdx
+++ b/src/content/roadmap/maplibre-tile-format/maplibre-tile-format/index.mdx
@@ -2,7 +2,7 @@
 title: MapLibre Tiles
 heroImage: "./image.png"
 heroImageFit: contain
-project: maplibre-tile-format
+project: [ maplibre-tile-format ]
 status: in-progress
 ---
 

--- a/src/content/roadmap/martin/data-cog/index.mdx
+++ b/src/content/roadmap/martin/data-cog/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: COG Support
 heroImage: "./image.png"
-project: martin-tile-server
+project: [ martin-tile-server ]
 status: in-progress
 ---
 

--- a/src/content/roadmap/martin/data-geojson/index.mdx
+++ b/src/content/roadmap/martin/data-geojson/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: GeoJSON Support
 heroImage: "./image.png"
-project: martin-tile-server
+project: [ martin-tile-server ]
 status: in-progress
 ---
 

--- a/src/content/roadmap/martin/data-geoparquet/index.mdx
+++ b/src/content/roadmap/martin/data-geoparquet/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: GeoParquet Support
 heroImage: "./image.png"
-project: martin-tile-server
+project: [ martin-tile-server ]
 status: under-consideration
 ---
 

--- a/src/content/roadmap/martin/data-mbtiles/index.mdx
+++ b/src/content/roadmap/martin/data-mbtiles/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: MBTiles Support
 heroImage: "./image.png"
-project: martin-tile-server
+project: [ martin-tile-server ]
 status: released
 released: December 2022
 ---

--- a/src/content/roadmap/martin/data-pmtiles/index.mdx
+++ b/src/content/roadmap/martin/data-pmtiles/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: PMTiles Support
 heroImage: "./image.png"
-project: martin-tile-server
+project: [ martin-tile-server ]
 status: released
 released: February 2023
 ---

--- a/src/content/roadmap/martin/data-postgis/index.mdx
+++ b/src/content/roadmap/martin/data-postgis/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL/PostGIS Integration
 heroImage: "./image.png"
-project: martin-tile-server
+project: [ martin-tile-server ]
 status: released
 released: January 2023
 ---

--- a/src/content/roadmap/martin/frontend/index.mdx
+++ b/src/content/roadmap/martin/frontend/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Frontend UI
 heroImage: "./image.png"
-project: martin-tile-server
+project: [ martin-tile-server ]
 status: released
 released: August 2025
 ---

--- a/src/content/roadmap/martin/martin-core-library/index.mdx
+++ b/src/content/roadmap/martin/martin-core-library/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Martin Core Library
 heroImage: "./image.png"
-project: martin-tile-server
+project: [ martin-tile-server ]
 status: released
 released: September 2025
 ---

--- a/src/content/roadmap/martin/observability/index.mdx
+++ b/src/content/roadmap/martin/observability/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Monitoring & Observability
 heroImage: "./image.png"
-project: martin-tile-server
+project: [ martin-tile-server ]
 status: in-progress
 ---
 

--- a/src/content/roadmap/martin/style-optimistation/index.mdx
+++ b/src/content/roadmap/martin/style-optimistation/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: Advanced Style-Data Cooptimization
 heroImage: "./image.png"
-project: martin-tile-server
-status: in-progress
+project: [ martin-tile-server ]
+status: under-consideration
 ---
 
 Together with the [Techical Unversity of Munichs' chair of Big Geospatial Data Management](https://www.bgd.ed.tum.de/), we are currently working on a thesis where the next generation of vector tile performance from tile servers could come from:

--- a/src/content/roadmap/martin/style-rendering/index.mdx
+++ b/src/content/roadmap/martin/style-rendering/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Style Rendering
 heroImage: "./image.png"
-project: martin-tile-server
+project: [ martin-tile-server ]
 status: in-progress
 ---
 

--- a/src/content/roadmap/martin/style-serving/index.mdx
+++ b/src/content/roadmap/martin/style-serving/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Style Serving
 heroImage: "./image.png"
-project: martin-tile-server
+project: [ martin-tile-server ]
 status: released
 released: April 2025
 ---

--- a/src/pages/roadmap/[project]/[item].astro
+++ b/src/pages/roadmap/[project]/[item].astro
@@ -17,14 +17,15 @@ export async function getStaticPaths() {
   const roadmapItems = await getCollection("roadmapItems");
 
   return roadmapItems.map((item) => {
-    const projectId = item.data.project ?? "general";
     const slug = item.id.split("/").slice(-1)[0];
 
-    return {
-      params: { project: projectId, item: slug },
-      props: { roadmapItemId: item.id },
-    };
-  });
+    return item.data.project.map((projectId) => {
+      return {
+        params: { project: projectId, item: slug },
+        props: { roadmapItemId: item.id },
+      };
+    });
+  }).flat();
 }
 
 const projectId = Astro.params.project ?? "general";
@@ -33,7 +34,7 @@ const itemSlug = Astro.params.item;
 const roadmapItems = await getCollection("roadmapItems");
 const roadmapItem = roadmapItems.find(
   (item) =>
-    (item.data.project ?? "general") === projectId &&
+    item.data.project.includes(projectId) &&
     item.id.split("/").slice(-1)[0] === itemSlug,
 );
 

--- a/src/pages/roadmap/[project]/index.astro
+++ b/src/pages/roadmap/[project]/index.astro
@@ -46,7 +46,7 @@ const projectMeta =
 
 const roadmapItems = await getCollection("roadmapItems");
 const projectItems = roadmapItems.filter(
-  (item) => (item.data.project ?? "general") === projectMeta.id,
+  (item) => item.data.project.includes(projectMeta.id),
 );
 
 function sortByReleaseDateDesc(items) {

--- a/src/pages/roadmap/index.astro
+++ b/src/pages/roadmap/index.astro
@@ -42,7 +42,7 @@ const roadmapItems = await getCollection("roadmapItems");
 
 function buildProjectStats(projectId: string) {
   const items = roadmapItems.filter(
-    (item) => (item.data.project ?? "general") === projectId,
+    (item) => item.data.project.includes(projectId),
   );
 
   const byStatus = sections.map((section) => ({


### PR DESCRIPTION
This allows items to belong to multiple projects while ensuring at least one project is always specified. The changes also include updates to route handling and filtering logic to work with the new array-based project field.

The primary motivation for this is that the MLT has items which are sort of cross-project, but duplicating them seems wastefull.

I tested that every page renders correctly