### PR TITLE
Fixed broken links to Step-by-Step Bounties Guide

### DIFF
--- a/src/content/news/2023-02-16-maplibre-newsletter-february-2023.mdx
+++ b/src/content/news/2023-02-16-maplibre-newsletter-february-2023.mdx
@@ -30,7 +30,7 @@ MapLibre Native for Android [v10.0.0](https://github.com/maplibre/maplibre-nativ
 
 ### Bounties 💰
 
-MapLibre Native published Bounties for code development tasks. Read our [step-by-step bounties guide](https://maplibre.org/roadmap/step-by-step-bounties-guide/) to learn how you can work on Bounties and get paid.
+MapLibre Native published Bounties for code development tasks. Read our [step-by-step bounties guide](https://maplibre.org/jobs/step-by-step-bounties-guide/) to learn how you can work on Bounties and get paid.
 
 Currently, the following Bounties are available (see [here](https://github.com/maplibre/maplibre-native/issues?q=is%3Aissue+is%3Aopen+label%3A%22%F0%9F%92%B0+bounty+L%22%2C%22%F0%9F%92%B0+bounty+S%22%2C%22%F0%9F%92%B0+bounty+M%22+) for an up-to-date list):
 
@@ -70,7 +70,7 @@ Ah, and MapLibre GL JS has now 4k Stars on GitHub ([star-history.com](https://st
 
 ### Bounties 💰
 
-MapLibre GL JS published Bounties for code development tasks. Read our [step-by-step bounties guide](https://maplibre.org/roadmap/step-by-step-bounties-guide/) to learn how you can work on Bounties and get paid.
+MapLibre GL JS published Bounties for code development tasks. Read our [step-by-step bounties guide](https://maplibre.org/jobs/step-by-step-bounties-guide/) to learn how you can work on Bounties and get paid.
 
 Currently, the following Bounties are available (see [here](https://github.com/maplibre/maplibre-gl-js/issues?q=is%3Aissue+is%3Aopen+label%3A%22%F0%9F%92%B0+bounty+L%22%2C%22%F0%9F%92%B0+bounty+S%22%2C%22%F0%9F%92%B0+bounty+M%22+) for an up-to-date list):
 

--- a/src/content/news/2023-03-13-second-call-for-bounties/index.mdx
+++ b/src/content/news/2023-03-13-second-call-for-bounties/index.mdx
@@ -46,7 +46,7 @@ The MapLibre Governing Board has already allocated USD 50,000 on Bounty directio
 
 ## Work on Bounties
 
-If you are interested in working on Bounties yourself, read our [step-by-step guide](https://maplibre.org/roadmap/step-by-step-bounties-guide/) and apply today at [https://maplibre.org/jobs](https://maplibre.org/jobs).
+If you are interested in working on Bounties yourself, read our [step-by-step guide](https://maplibre.org/jobs/step-by-step-bounties-guide/) and apply today at [https://maplibre.org/jobs](https://maplibre.org/jobs).
 
 ## Contact
 

--- a/src/content/news/2023-03-20-maplibre-newsletter-march-2023/index.mdx
+++ b/src/content/news/2023-03-20-maplibre-newsletter-march-2023/index.mdx
@@ -19,7 +19,7 @@ We invite you to share feedback on what features and improvements in MapLibre GL
 
 The MapLibre Governing Board will take your feedback and decide how to allocate Bounty resources on roadmap projects on April 4th, 2023.
 
-Several Bounties are up for takers now. If you would like to work on Bounties, have a look at our updated [step-by-step Bounties guide](https://maplibre.org/roadmap/step-by-step-bounties-guide/).
+Several Bounties are up for takers now. If you would like to work on Bounties, have a look at our updated [step-by-step Bounties guide](https://maplibre.org/jobs/step-by-step-bounties-guide/).
 
 We encourage individuals and companies to propose epics, i.e., a series of tickets which together move MapLibre forward in one of the Bounty directions. You are free to suggest the Bounty size on each ticket yourself and propose splitting all the available resources of a Bounty direction on the tickets of your epic. A maintainer will consider your proposal and confirm the Bounty sizes.
 

--- a/src/content/news/2023-06-07-maplibre-rs-monthly.mdx
+++ b/src/content/news/2023-06-07-maplibre-rs-monthly.mdx
@@ -19,7 +19,7 @@ Actually, we have great news about the project.
 
 #### What does that mean?
 
-You may wonder what that means: The gist of it is that the project can now use donations to the MapLibre organization to incentivize development. As of today, it is not 100% clear how that will work out. One possibility is to use the existing [bounty program](https://maplibre.org/roadmap/step-by-step-bounties-guide/) to set a bounty for issues. But we are actively looking for ideas to put the donation to good use.
+You may wonder what that means: The gist of it is that the project can now use donations to the MapLibre organization to incentivize development. As of today, it is not 100% clear how that will work out. One possibility is to use the existing [bounty program](https://maplibre.org/jobs/step-by-step-bounties-guide/) to set a bounty for issues. But we are actively looking for ideas to put the donation to good use.
 
 #### Why did maplibre-rs become a sponsored project?
 

--- a/src/content/news/2023-06-23-maplibre-newsletter-june-2023/index.mdx
+++ b/src/content/news/2023-06-23-maplibre-newsletter-june-2023/index.mdx
@@ -67,4 +67,4 @@ The `mbtiles` tool lets users partially copy an mbtiles file, filtering to speci
 
 As with every newsletter, we would like to call attention to the fact that we have monetary awards available for developers wanting to push MapLibre forward in [one of the Bounty Directions](https://github.com/maplibre/maplibre/issues?q=is%3Aissue+is%3Aopen+label%3A%22bounty+direction%22). For MapLibre Native in particular, we are looking for **iOS developers with Objective-C experience** to help [modernize the iOS codebase](https://github.com/maplibre/maplibre-native/issues/1248).
 
-Check out the [Step-by-Step Bounties Guide](https://maplibre.org/roadmap/step-by-step-bounties-guide/) and get in touch via GitHub or [Slack](https://slack.openstreetmap.us/) (`#maplibre-native`).
+Check out the [Step-by-Step Bounties Guide](https://maplibre.org/jobs/step-by-step-bounties-guide/) and get in touch via GitHub or [Slack](https://slack.openstreetmap.us/) (`#maplibre-native`).

--- a/src/pages/jobs/developer-job-posting.astro
+++ b/src/pages/jobs/developer-job-posting.astro
@@ -28,8 +28,8 @@ import Layout from "../../layouts/Layout.astro";
 
         <p>
           Before applying to the Developer role make sure to read our
-          <a href="https://maplibre.org/roadmap/step-by-step-bounties-guide/"
-            >step by step bounties guide</a
+          <a href="https://maplibre.org/jobs/step-by-step-bounties-guide/"
+            >step-by-step bounties guide</a
           >.
         </p>
         <p>


### PR DESCRIPTION
Also added a couple of missing hyphens to `developer-job-posting.astro` for "step-by-step" consistency.