### PR TITLE
Include SOTM EU to conferences

### DIFF
--- a/src/content/news/2025-11-04-maplibre-newsletter-october-2025/index.mdx
+++ b/src/content/news/2025-11-04-maplibre-newsletter-october-2025/index.mdx
@@ -237,9 +237,10 @@ Thanks again to everyone in the community for making this possible!
 We plan to participate and contribute to sessions/workshops in the following events this month.
 
 - [FOSS4G North America 2025](https://www.foss4gna.org/), 3-4 Nov, 2025
+- [SOTM EU 2025](https://2025.stateofthemap.eu/), 14-15 Nov, 2025 in Scotland. Watch out for [Bart Louwers workshop](https://pretalx.com/sotmeu2025/talk/QFFEAW/)!
 - [FOSS4G Global](https://2025.foss4g.org/), 17-23 Nov, 2025 in Auckland
 
-Talks to watch out for:
+FOSS4G Talks to watch out for:
 
 <p style="margin-bottom: 0.5rem; color:#666; font-size: 0.85rem;">
   *All times are in Pacific/Auckland (NZDT).*


### PR DESCRIPTION
This patch adds SOTM EU and Bart's talk to the October newsletter.

<img width="849" height="251" alt="image" src="https://github.com/user-attachments/assets/d367febd-4896-4068-9526-22522d50efca" />
