### PR TITLE
Add privacy policy MapLibreTestApp iOS

### DIFF
--- a/src/pages/privacy-policy-ios-testapp.astro
+++ b/src/pages/privacy-policy-ios-testapp.astro
@@ -19,7 +19,7 @@ import TitleHeader from "../components/TitleHeader.astro";
         <p>
           Crashes are reported to a MapLibre Sentry account accessible by
           MapLibre developers. Crash information may include information like IP
-          address, device type and logs (which may contain GPS coordinates is
+          address, device type and logs (which may contain GPS coordinates if
           permissions where given). Do not run the MapLibreTestApp if you are
           not comfortable with this.
         </p>


### PR DESCRIPTION
I am distributing an iOS app, so we need a privacy policy for it.