### PR TITLE
Fix reference from MLT to MVT in index.mdx

### DIFF
--- a/src/content/news/2026-01-23-mlt-release/index.mdx
+++ b/src/content/news/2026-01-23-mlt-release/index.mdx
@@ -44,7 +44,7 @@ It has been redesigned from the ground up to address the challenges of rapidly g
 and complex next-generation geospatial source formats as well as to leverage the capabilities of modern hardware and APIs.
 
 MLT is specifically designed for modern and next generation graphics APIs to enable high-performance processing and rendering of
-large (planet-scale) 2D and 2.5 basemaps. This current implementation offers feature parity with MLT[^1] while delivering on the following:
+large (planet-scale) 2D and 2.5 basemaps. This current implementation offers feature parity with MVT[^1] while delivering on the following:
 
 [^1]: One exception: unlike MVT, MLT does not support layers where a value in a column changes type from feature to feature.
 


### PR DESCRIPTION
Corrected a reference from MLT to MVT in the documentation.