### PR TITLE
fix: correct typo in .gitignore (link-cherker -> link-checker)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ pnpm-debug.log*
 resources/
 static/
 
-.link-cherker
+.link-checker


### PR DESCRIPTION
## Summary
Fixed typo in `.gitignore`: `link-cherker` → `link-checker`

## Test plan
No tests needed - simple typo fix in gitignore file.
