### PR TITLE
fix: correct typos in MLT release post and board member bio

### DIFF
--- a/src/content/bio/haowen-you/index.md
+++ b/src/content/bio/haowen-you/index.md
@@ -21,6 +21,6 @@ The past year has shown me the power and impact of our community when we all wor
 
 These achievements are not possible without some key individuals' hard work. At the same time, I view them as testaments to our community's collective strength. They reinforce my belief in MapLibre's potential and motivate me to continue to devote myself to supporting our community's growth and success.
 
-On the on the governing board, I will continue my role as a bridge between MapLibre and major corporate adopters and sponsors. I will continue my commitment to connecting common interests, facilitating the exchange of ideas, and helping navigate diverging interests when they arise. I will drive for further growth in adoptions, contributions, and sponsorships to ensure MapLibre's long-term sustainability and success.
+On the governing board, I will continue my role as a bridge between MapLibre and major corporate adopters and sponsors. I will continue my commitment to connecting common interests, facilitating the exchange of ideas, and helping navigate diverging interests when they arise. I will drive for further growth in adoptions, contributions, and sponsorships to ensure MapLibre's long-term sustainability and success.
 
 I'm honored to continue serving our community for another term. I believe together, we will build on our momentum and achieve even more in the coming year.

--- a/src/content/news/2026-01-23-mlt-release/index.mdx
+++ b/src/content/news/2026-01-23-mlt-release/index.mdx
@@ -39,7 +39,7 @@ Today we are happy to announce **MapLibre Tile** (MLT), a new modern and efficie
 
 ## What is MapLibre Tile?
 
-MapLibre Tile (MLT) is a succesor to [Mapbox Vector Tile (MVT)](https://github.com/mapbox/vector-tile-spec).
+MapLibre Tile (MLT) is a successor to [Mapbox Vector Tile (MVT)](https://github.com/mapbox/vector-tile-spec).
 It has been redesigned from the ground up to address the challenges of rapidly growing geospatial data volumes
 and complex next-generation geospatial source formats, as well as to leverage the capabilities of modern hardware and APIs.
 


### PR DESCRIPTION
## Summary
- Fix "succesor" → "successor" in MLT release article
- Remove duplicate "On the on the" → "On the" in Haowen You's bio

## Test plan
No tests needed — text-only changes.