### PR TITLE
Make sure the footer is at the bottom

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -107,5 +107,5 @@ import { ClientRouter, fade } from "astro:transitions";
     min-height: 100vh;
     display: flex;
     flex-direction: column;
-	}
+  }
 </style>


### PR DESCRIPTION
Chunking #535  for easier review

On pages that aren't very long, the footer would be right below the content instead of at the bottom.

**Before**

<img width="1200" height="1040" alt="Screenshot 2026-02-11 at 22 42 37" src="https://github.com/user-attachments/assets/be9ddf26-c657-41c8-bf11-1ddfa0a3f020" />

**After**

<img width="1183" height="1042" alt="Screenshot 2026-02-11 at 22 42 16" src="https://github.com/user-attachments/assets/7a70dd96-ac04-492f-a213-83e56ee1b28d" />
