### PR TITLE
Update CalTopo announcement with sponsorship details

### DIFF
--- a/src/content/news/2026-02-16-caltopo-announcement/index.mdx
+++ b/src/content/news/2026-02-16-caltopo-announcement/index.mdx
@@ -53,10 +53,24 @@ CalTopo has built one of the most trusted field mapping platforms in the US, rel
 
 CalTopo is an app for collaborative map building and offline adventuring, and they rely heavily on MapLibre powering their [3D maps](https://caltopo.com/map.html#ll=38.80547,-98.41553&z=5&b=mbt), making it possible for users to explore terrain in a more intuitive, visual way.
 
-<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", marginBottom: "2rem" }}>
+<div
+  style={{
+    position: "relative",
+    paddingBottom: "56.25%",
+    height: 0,
+    overflow: "hidden",
+    marginBottom: "2rem",
+  }}
+>
   <iframe
     src="https://player.vimeo.com/video/836970545"
-    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%" }}
+    style={{
+      position: "absolute",
+      top: 0,
+      left: 0,
+      width: "100%",
+      height: "100%",
+    }}
     frameBorder="0"
     allow="autoplay; fullscreen; picture-in-picture"
     allowFullScreen


### PR DESCRIPTION
This PR is build on top of @ramyaragupathy's `sponsor-caltopo` branch, to implement additional suggestions. I incorporated @louwers's suggestions, with my own changes.

- add preamble explaining who CalTopo is - additional details beyond what Bart suggested.
- add video / player - I suggest showning https://vimeo.com/836970545 (the second most popular of their Vimeos) rather than https://vimeo.com/553057280 (the one Bart suggested) only because it presents a better overview in the first 2 minutes.

I have some tiny hesitation about including training videos in the post and agree with @ramyaragupathy that it would be better if THEY were providing this... maybe if we tell them we are incorporating this they will approve it or suggest what they prefer?