### PR TITLE
docs: add donation fee guidance to sponsors page

### DIFF
--- a/src/pages/sponsors/index.astro
+++ b/src/pages/sponsors/index.astro
@@ -225,16 +225,16 @@ title: "Sponsors";
         </p>
         <ul>
           <li>
-            <strong>GitHub Sponsors (organizations):</strong> Use invoice billing or
-            pay from your GitHub account credit balance to avoid the 3% card
-            processing fee.
+            <strong>GitHub Sponsors (organizations):</strong> Use invoice billing
+            or pay from your GitHub account credit balance to avoid the 3% card processing
+            fee.
           </li>
           <li>
             <strong>OpenCollective:</strong> No card processing fee, but a host fee
             applies. Generally the preferred option for most donors.
           </li>
         </ul>
-     
+
         <hr />
 
         <!-- In-Kind Contributions -->


### PR DESCRIPTION
Adds a "How to Donate Without Extra Fees" section under Individual Donations, explaining how to avoid card processing fees on GitHub Sponsors and OpenCollective.

Closes #559

- [x]  Documented how to donate in order to avoid excess credit card or transaction fees.
- [x]  Modify the Sponsor page on the website
