### PR TITLE
CommunityMap: use unavatar instead of loading avatars from GitHub CDN

### DIFF
--- a/src/components/CommunityMap.tsx
+++ b/src/components/CommunityMap.tsx
@@ -74,7 +74,7 @@ export const CommunityMap = (props: any) => {
         }
       });
 
-      img.src = `https://github.com/${person.github}.png?size=80`;
+      img.src = `https://unavatar.io/github/${person.github}?fallback=false`;
     });
   });
 


### PR DESCRIPTION
Seems to work really well for me.

Loads instantly and no 429.

