### PR TITLE
Remove announcement icon from Announcement component

### DIFF
--- a/src/components/Announcement.astro
+++ b/src/components/Announcement.astro
@@ -3,9 +3,6 @@
 ---
 
 <div class="announcement-callout">
-  <div class="announcement-icon">
-    <slot name="icon">📣</slot>
-  </div>
   <div class="announcement-content">
     <slot />
   </div>
@@ -21,12 +18,6 @@
     display: flex;
     align-items: flex-start; /* Aligns icon with the top of the text */
     gap: 16px;
-  }
-
-  .announcement-icon {
-    font-size: 1.5rem;
-    flex-shrink: 0; /* Prevents the icon from squishing */
-    line-height: 1.2;
   }
 
   .announcement-content {


### PR DESCRIPTION
looks broken currently and "vibed" 😉 

<img width="1481" height="931" alt="image" src="https://github.com/user-attachments/assets/d96b02f5-1aec-4234-9ba9-db6e041e81c9" />
