### PR TITLE
add missing contrib

### DIFF
--- a/src/content/news/2026-03-03-maplibre-newsletter-february-2026/index.mdx
+++ b/src/content/news/2026-03-03-maplibre-newsletter-february-2026/index.mdx
@@ -10,7 +10,7 @@ authors:
     ramya-ragupathy,
     joscha-eckert,
     stephanie-may,
-		birk-skyum
+    birk-skyum
   ]
 draft: false
 ---

--- a/src/content/news/2026-03-03-maplibre-newsletter-february-2026/index.mdx
+++ b/src/content/news/2026-03-03-maplibre-newsletter-february-2026/index.mdx
@@ -10,7 +10,7 @@ authors:
     ramya-ragupathy,
     joscha-eckert,
     stephanie-may,
-    birk-skyum
+    birk-skyum,
   ]
 draft: false
 ---

--- a/src/content/news/2026-03-03-maplibre-newsletter-february-2026/index.mdx
+++ b/src/content/news/2026-03-03-maplibre-newsletter-february-2026/index.mdx
@@ -10,6 +10,7 @@ authors:
     ramya-ragupathy,
     joscha-eckert,
     stephanie-may,
+		birk-skyum
   ]
 draft: false
 ---

--- a/src/content/news/2026-05-02-maplibre-newsletter-april-2026/index.mdx
+++ b/src/content/news/2026-05-02-maplibre-newsletter-april-2026/index.mdx
@@ -70,7 +70,7 @@ It has been over a year since our last major update, and we believe now is the r
 
 As always, we would like to thank all our contributors:
 
-👏 [Xavier Bourry](https://github.com/xavierjs), [Frank Elsing](https://github.com/CommanderStorm), [Jakub Pelc](https://github.com/kubapelc), [itisyb](https://github.com/itisyb), [Yu Chun Tsao](https://github.com/YuChunTsao), [neodescis](https://github.com/neodescis), [Matt Van Horn](https://github.com/mvanhorn), [Will Field](https://github.com/Willjfield), [Ashwin Chandran](https://github.com/ashwinuae), [Seokcheol Jeong](https://github.com/kkokkojeong), [Sam](https://github.com/Lievesley), and [Kyℓe Hensel](https://github.com/k-yle).
+👏 [Xavier Bourry](https://github.com/xavierjs), [Frank Elsing](https://github.com/CommanderStorm), [Birk Skyum](github.com/birkskyum), [Jakub Pelc](https://github.com/kubapelc), [itisyb](https://github.com/itisyb), [Yu Chun Tsao](https://github.com/YuChunTsao), [neodescis](https://github.com/neodescis), [Matt Van Horn](https://github.com/mvanhorn), [Will Field](https://github.com/Willjfield), [Ashwin Chandran](https://github.com/ashwinuae), [Seokcheol Jeong](https://github.com/kkokkojeong), [Sam](https://github.com/Lievesley), and [Kyℓe Hensel](https://github.com/k-yle).
 
 ## 🧩 MapLibre Tile (MLT)
 

--- a/src/content/news/2026-05-02-maplibre-newsletter-april-2026/index.mdx
+++ b/src/content/news/2026-05-02-maplibre-newsletter-april-2026/index.mdx
@@ -70,7 +70,7 @@ It has been over a year since our last major update, and we believe now is the r
 
 As always, we would like to thank all our contributors:
 
-👏 [Xavier Bourry](https://github.com/xavierjs), [Frank Elsing](https://github.com/CommanderStorm), [Birk Skyum](github.com/birkskyum), [Jakub Pelc](https://github.com/kubapelc), [itisyb](https://github.com/itisyb), [Yu Chun Tsao](https://github.com/YuChunTsao), [neodescis](https://github.com/neodescis), [Matt Van Horn](https://github.com/mvanhorn), [Will Field](https://github.com/Willjfield), [Ashwin Chandran](https://github.com/ashwinuae), [Seokcheol Jeong](https://github.com/kkokkojeong), [Sam](https://github.com/Lievesley), and [Kyℓe Hensel](https://github.com/k-yle).
+👏 [Xavier Bourry](https://github.com/xavierjs), [Frank Elsing](https://github.com/CommanderStorm), [Birk Skyum](https://github.com/birkskyum), [Jakub Pelc](https://github.com/kubapelc), [itisyb](https://github.com/itisyb), [Yu Chun Tsao](https://github.com/YuChunTsao), [neodescis](https://github.com/neodescis), [Matt Van Horn](https://github.com/mvanhorn), [Will Field](https://github.com/Willjfield), [Ashwin Chandran](https://github.com/ashwinuae), [Seokcheol Jeong](https://github.com/kkokkojeong), [Sam](https://github.com/Lievesley), and [Kyℓe Hensel](https://github.com/k-yle).
 
 ## 🧩 MapLibre Tile (MLT)
 


### PR DESCRIPTION
I'm adding myself to the code contrib of GL JS in April because i did a large amount amount of work on both ESM-only (one of the two bullets featured for the month) **and** on a complete build-pipeline overhaul.

I'm adding myself as author on the February newsletter where i contributed the maplibre-rs section and all the work associated to it.