### PR TITLE
Add "Get Involved" section to roadmap item pages

### DIFF
--- a/src/components/HelpWanted.astro
+++ b/src/components/HelpWanted.astro
@@ -10,15 +10,19 @@ const { developerLink, fundingLink } = Astro.props;
 <div class="mt-4">
   <h5>Get Involved</h5>
   <div class="d-flex gap-3 flex-wrap mt-2">
-    {developerLink && (
-      <a href={developerLink} class="btn btn-outline-light">
-        Technical Discussion
-      </a>
-    )}
-    {fundingLink && (
-      <a href={fundingLink} class="btn btn-primary">
-        Funding
-      </a>
-    )}
+    {
+      developerLink && (
+        <a href={developerLink} class="btn btn-outline-light">
+          Technical Discussion
+        </a>
+      )
+    }
+    {
+      fundingLink && (
+        <a href={fundingLink} class="btn btn-primary">
+          Funding
+        </a>
+      )
+    }
   </div>
 </div>

--- a/src/components/HelpWanted.astro
+++ b/src/components/HelpWanted.astro
@@ -1,0 +1,24 @@
+---
+interface Props {
+  developerLink?: string;
+  fundingLink?: string;
+}
+
+const { developerLink, fundingLink } = Astro.props;
+---
+
+<div class="mt-4">
+  <h5>Get Involved</h5>
+  <div class="d-flex gap-3 flex-wrap mt-2">
+    {developerLink && (
+      <a href={developerLink} class="btn btn-outline-light">
+        Technical Discussion
+      </a>
+    )}
+    {fundingLink && (
+      <a href={fundingLink} class="btn btn-primary">
+        Funding
+      </a>
+    )}
+  </div>
+</div>

--- a/src/components/HelpWanted.astro
+++ b/src/components/HelpWanted.astro
@@ -1,25 +1,25 @@
 ---
 interface Props {
-  developerLink?: string;
-  fundingLink?: string;
+  developer?: string;
+  funding?: string;
 }
 
-const { developerLink, fundingLink } = Astro.props;
+const { developer, funding } = Astro.props;
 ---
 
 <div class="mt-4">
   <h5>Get Involved</h5>
   <div class="d-flex gap-3 flex-wrap mt-2">
     {
-      developerLink && (
-        <a href={developerLink} class="btn btn-outline-light">
+      developer && (
+        <a href={developer} class="btn btn-outline-light">
           Technical Discussion
         </a>
       )
     }
     {
-      fundingLink && (
-        <a href={fundingLink} class="btn btn-primary">
+      funding && (
+        <a href={funding} class="btn btn-primary">
           Funding
         </a>
       )

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -48,6 +48,9 @@ const roadmapItems = defineCollection({
           return new Date(`${month} 1, ${year}`);
         }),
       ),
+      helpWanted: z.optional(z.boolean()),
+      developerLink: z.optional(z.string().url()),
+      fundingLink: z.optional(z.string().url()),
     }),
 });
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -48,10 +48,12 @@ const roadmapItems = defineCollection({
           return new Date(`${month} 1, ${year}`);
         }),
       ),
-      links: z.optional(z.object({
-        developer: z.optional(z.string().url()),
-        funding: z.optional(z.string().url()),
-      })),
+      links: z.optional(
+        z.object({
+          developer: z.optional(z.string().url()),
+          funding: z.optional(z.string().url()),
+        }),
+      ),
     }),
 });
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -48,9 +48,10 @@ const roadmapItems = defineCollection({
           return new Date(`${month} 1, ${year}`);
         }),
       ),
-      helpWanted: z.optional(z.boolean()),
-      developerLink: z.optional(z.string().url()),
-      fundingLink: z.optional(z.string().url()),
+      links: z.optional(z.object({
+        developer: z.optional(z.string().url()),
+        funding: z.optional(z.string().url()),
+      })),
     }),
 });
 

--- a/src/content/roadmap/maplibre-gl-js/blending-modes/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/blending-modes/index.mdx
@@ -3,9 +3,9 @@ title: Blending Modes
 heroImage: "./image.png"
 project: maplibre-gl-js
 status: under-consideration
-helpWanted: true
-developerLink: https://github.com/maplibre/maplibre/discussions/170
-fundingLink: https://opencollective.com/maplibre/projects/blending-modes
+links:
+  developer: https://github.com/maplibre/maplibre/discussions/170
+  funding: https://opencollective.com/maplibre
 ---
 
 Goal:

--- a/src/content/roadmap/maplibre-gl-js/blending-modes/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/blending-modes/index.mdx
@@ -3,6 +3,9 @@ title: Blending Modes
 heroImage: "./image.png"
 project: maplibre-gl-js
 status: under-consideration
+helpWanted: true
+developerLink: https://github.com/maplibre/maplibre/discussions/170
+fundingLink: https://opencollective.com/maplibre/projects/blending-modes
 ---
 
 Goal:
@@ -10,5 +13,3 @@ Goal:
 - Enable per-layer or per-feature blending modes as multiply, add, overlay, lighten, darken, etc.
 
 Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/7/77/Hue_alpha_falloff.svg">Wikipedia</a>
-
-Discussion Thread: [#170](https://github.com/maplibre/maplibre/discussions/170).

--- a/src/content/roadmap/maplibre-gl-js/graphics-modernization/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/graphics-modernization/index.mdx
@@ -3,6 +3,9 @@ title: Graphics Modernization
 heroImage: "./graphics-modernization.png"
 project: maplibre-gl-js
 status: in-progress
+helpWanted: true
+developerLink: https://github.com/maplibre/maplibre-gl-js/issues/7640
+fundingLink: https://opencollective.com/maplibre/projects/graphics-modernization
 ---
 
 MapLibre GL JS is getting a WebGPU rendering backend alongside the existing WebGL2 renderer. As part of this effort, the WebGL2 renderer is also being modernized to use features like Uniform Buffer Objects, immutable textures, and layout qualifiers that bring it closer to how WebGPU works.
@@ -18,4 +21,4 @@ The work is split into four phases:
 
 Each phase is independently shippable. The WebGL2 improvements in phases 1-3 prepare the codebase so that adding WebGPU in phase 4 is a contained change rather than a rewrite.
 
-Progress can be followed in the [Graphics Modernization](https://github.com/maplibre/maplibre-gl-js/issues/7640) tracking issue. If you are interested in contributing, please reach out on Slack (`#maplibre-gl-js`) or comment on the issue.
+If you are interested in contributing, reach out on Slack (`#maplibre-gl-js`).

--- a/src/content/roadmap/maplibre-gl-js/graphics-modernization/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/graphics-modernization/index.mdx
@@ -3,9 +3,9 @@ title: Graphics Modernization
 heroImage: "./graphics-modernization.png"
 project: maplibre-gl-js
 status: in-progress
-helpWanted: true
-developerLink: https://github.com/maplibre/maplibre-gl-js/issues/7640
-fundingLink: https://opencollective.com/maplibre/projects/graphics-modernization
+links:
+  developer: https://github.com/maplibre/maplibre-gl-js/issues/7640
+  funding: https://opencollective.com/maplibre
 ---
 
 MapLibre GL JS is getting a WebGPU rendering backend alongside the existing WebGL2 renderer. As part of this effort, the WebGL2 renderer is also being modernized to use features like Uniform Buffer Objects, immutable textures, and layout qualifiers that bring it closer to how WebGPU works.

--- a/src/content/roadmap/maplibre-gl-js/non-mercator-projection/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/non-mercator-projection/index.mdx
@@ -3,6 +3,9 @@ title: Non-Mercator Projection
 heroImage: "./image.png"
 project: maplibre-gl-js
 status: under-consideration
+helpWanted: true
+developerLink: https://github.com/maplibre/maplibre/discussions/163
+fundingLink: https://opencollective.com/maplibre/projects/non-mercator-js
 ---
 
 Goals:
@@ -12,5 +15,3 @@ Goals:
 - Specify EPSG coordinate system and tile matrix set
 
 Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/f/fa/Mercator-proj.png">Wikipedia</a>
-
-Discussion Thread: [#163](https://github.com/maplibre/maplibre/discussions/163).

--- a/src/content/roadmap/maplibre-gl-js/non-mercator-projection/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/non-mercator-projection/index.mdx
@@ -3,9 +3,9 @@ title: Non-Mercator Projection
 heroImage: "./image.png"
 project: maplibre-gl-js
 status: under-consideration
-helpWanted: true
-developerLink: https://github.com/maplibre/maplibre/discussions/163
-fundingLink: https://opencollective.com/maplibre/projects/non-mercator-js
+links:
+  developer: https://github.com/maplibre/maplibre/discussions/163
+  funding: https://opencollective.com/maplibre
 ---
 
 Goals:

--- a/src/content/roadmap/maplibre-gl-js/svg-symbol-source/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/svg-symbol-source/index.mdx
@@ -3,9 +3,9 @@ title: SVG Symbol Source
 heroImage: "./image.png"
 project: maplibre-gl-js
 status: under-consideration
-helpWanted: true
-developerLink: https://github.com/maplibre/maplibre/discussions/175
-fundingLink: https://opencollective.com/maplibre/projects/svg-symbol-source
+links:
+  developer: https://github.com/maplibre/maplibre/discussions/175
+  funding: https://opencollective.com/maplibre
 ---
 
 Goal:

--- a/src/content/roadmap/maplibre-gl-js/svg-symbol-source/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/svg-symbol-source/index.mdx
@@ -3,6 +3,9 @@ title: SVG Symbol Source
 heroImage: "./image.png"
 project: maplibre-gl-js
 status: under-consideration
+helpWanted: true
+developerLink: https://github.com/maplibre/maplibre/discussions/175
+fundingLink: https://opencollective.com/maplibre/projects/svg-symbol-source
 ---
 
 Goal:
@@ -11,4 +14,4 @@ Goal:
 
 Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/SVG_logo.svg/768px-SVG_logo.svg.png">Wikipedia</a>
 
-Discussion Thread: [#175](https://github.com/maplibre/maplibre/discussions/175) as well as the [MapLibre Style Spec](https://maplibre.org/maplibre-style-spec/layers/#symbol).
+See also the [MapLibre Style Spec](https://maplibre.org/maplibre-style-spec/layers/#symbol).

--- a/src/content/roadmap/maplibre-gl-js/writing-systems/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/writing-systems/index.mdx
@@ -3,9 +3,9 @@ title: Writing Systems
 heroImage: "./image.png"
 project: maplibre-gl-js
 status: under-consideration
-helpWanted: true
-developerLink: https://github.com/maplibre/maplibre-gl-js/pull/4564
-fundingLink: https://opencollective.com/maplibre/projects/writing-systems-js
+links:
+  developer: https://github.com/maplibre/maplibre-gl-js/pull/4564
+  funding: https://opencollective.com/maplibre
 ---
 
 ## MapLibre GL JS

--- a/src/content/roadmap/maplibre-gl-js/writing-systems/index.mdx
+++ b/src/content/roadmap/maplibre-gl-js/writing-systems/index.mdx
@@ -3,6 +3,9 @@ title: Writing Systems
 heroImage: "./image.png"
 project: maplibre-gl-js
 status: under-consideration
+helpWanted: true
+developerLink: https://github.com/maplibre/maplibre-gl-js/pull/4564
+fundingLink: https://opencollective.com/maplibre/projects/writing-systems-js
 ---
 
 ## MapLibre GL JS
@@ -45,6 +48,4 @@ import { Image } from "astro:assets";
   </p>
 </div>
 
-See [#4564](https://github.com/maplibre/maplibre-gl-js/pull/4564) which will allow rendering local (web) fonts with TinySDF.
-
-Also see [maplibre-gl-complex-text](https://github.com/wipfli/maplibre-gl-complex-text) for a plugin-based approach for rendering complex texts.
+See [maplibre-gl-complex-text](https://github.com/wipfli/maplibre-gl-complex-text) for a plugin-based approach for rendering complex texts.

--- a/src/content/roadmap/maplibre-native/globe-view/index.mdx
+++ b/src/content/roadmap/maplibre-native/globe-view/index.mdx
@@ -3,13 +3,12 @@ title: Globe View
 heroImage: "./image.png"
 project: maplibre-native
 status: partially-funded
+helpWanted: true
+developerLink: https://github.com/maplibre/maplibre-native/issues/3161
+fundingLink: https://opencollective.com/maplibre/projects/globe-view-native
 ---
 
 Goals:
 
 - Zoom out via Adaptive Composite Map Projection
 - Ability to show and interact with Globe (or alternative view on earth) when map is zoomed out - while reusing and loading the same Mercator vector tile and raster data - client side reprojection of the data - using Adaptive Composite Map Projection - where deeply zoomed you are in Mercator - but from certain zoom level up there is transition to another projection.
-
-Issue: https://github.com/maplibre/maplibre-native/issues/3161
-
-**Partially funded, please reach out to team@maplibre.org if you are interested in co-sponsoring this feature.**

--- a/src/content/roadmap/maplibre-native/globe-view/index.mdx
+++ b/src/content/roadmap/maplibre-native/globe-view/index.mdx
@@ -3,9 +3,9 @@ title: Globe View
 heroImage: "./image.png"
 project: maplibre-native
 status: partially-funded
-helpWanted: true
-developerLink: https://github.com/maplibre/maplibre-native/issues/3161
-fundingLink: https://opencollective.com/maplibre/projects/globe-view-native
+links:
+  developer: https://github.com/maplibre/maplibre-native/issues/3161
+  funding: https://opencollective.com/maplibre
 ---
 
 Goals:

--- a/src/content/roadmap/maplibre-native/low-memory-hardening/index.mdx
+++ b/src/content/roadmap/maplibre-native/low-memory-hardening/index.mdx
@@ -3,8 +3,8 @@ title: Low-memory Hardening
 project: maplibre-native
 heroImage: "./image.png"
 status: in-progress
-helpWanted: true
-fundingLink: https://opencollective.com/maplibre/projects/low-memory-hardening-native
+links:
+  funding: https://opencollective.com/maplibre
 ---
 
 We are working on hardening MapLibre Native under low-memory conditions (both RAM and GPU memory). You can think of:

--- a/src/content/roadmap/maplibre-native/low-memory-hardening/index.mdx
+++ b/src/content/roadmap/maplibre-native/low-memory-hardening/index.mdx
@@ -3,6 +3,8 @@ title: Low-memory Hardening
 project: maplibre-native
 heroImage: "./image.png"
 status: in-progress
+helpWanted: true
+fundingLink: https://opencollective.com/maplibre/projects/low-memory-hardening-native
 ---
 
 We are working on hardening MapLibre Native under low-memory conditions (both RAM and GPU memory). You can think of:

--- a/src/content/roadmap/maplibre-native/non-mercator-projection/index.mdx
+++ b/src/content/roadmap/maplibre-native/non-mercator-projection/index.mdx
@@ -3,6 +3,9 @@ title: Non-Mercator Projection
 heroImage: "./image.png"
 project: maplibre-native
 status: under-consideration
+helpWanted: true
+developerLink: https://github.com/maplibre/maplibre/discussions/163
+fundingLink: https://opencollective.com/maplibre/projects/non-mercator-native
 ---
 
 Goals:
@@ -12,5 +15,3 @@ Goals:
 - Specify EPSG coordinate system and tile matrix set
 
 Image Credit: <a href="https://upload.wikimedia.org/wikipedia/commons/f/fa/Mercator-proj.png">Wikipedia</a>
-
-Discussion Thread: [#163](https://github.com/maplibre/maplibre/discussions/163).

--- a/src/content/roadmap/maplibre-native/non-mercator-projection/index.mdx
+++ b/src/content/roadmap/maplibre-native/non-mercator-projection/index.mdx
@@ -3,9 +3,9 @@ title: Non-Mercator Projection
 heroImage: "./image.png"
 project: maplibre-native
 status: under-consideration
-helpWanted: true
-developerLink: https://github.com/maplibre/maplibre/discussions/163
-fundingLink: https://opencollective.com/maplibre/projects/non-mercator-native
+links:
+  developer: https://github.com/maplibre/maplibre/discussions/163
+  funding: https://opencollective.com/maplibre
 ---
 
 Goals:

--- a/src/content/roadmap/maplibre-native/plugin-api/index.mdx
+++ b/src/content/roadmap/maplibre-native/plugin-api/index.mdx
@@ -3,9 +3,9 @@ title: Plugin API
 heroImage: "./image.jpg"
 project: maplibre-native
 status: in-progress
-helpWanted: true
-developerLink: https://github.com/maplibre/maplibre-native/discussions/4321
-fundingLink: https://opencollective.com/maplibre/projects/plugin-api-native
+links:
+  developer: https://github.com/maplibre/maplibre-native/discussions/4321
+  funding: https://opencollective.com/maplibre
 ---
 
 We are experimenting with various ways to add plugins for extending MapLibre Native.

--- a/src/content/roadmap/maplibre-native/plugin-api/index.mdx
+++ b/src/content/roadmap/maplibre-native/plugin-api/index.mdx
@@ -3,12 +3,13 @@ title: Plugin API
 heroImage: "./image.jpg"
 project: maplibre-native
 status: in-progress
+helpWanted: true
+developerLink: https://github.com/maplibre/maplibre-native/pull/3703
+fundingLink: https://opencollective.com/maplibre/projects/plugin-api-native
 ---
 
 We are experimenting with various ways to add plugins for extending MapLibre Native.
 
 [Plugin Layers](https://maplibre.org/maplibre-native/ios/latest/documentation/maplibre-native-for-ios/pluginlayers) allow custom rendering to intergrate with custom style layers (as of October 2025, only available for iOS).
-
-See [#3703](https://github.com/maplibre/maplibre-native/pull/3703) for other suggested plugin APIs.
 
 Meta developed a cross-platform plugin API that allows extending MapLibre Native with plugins written in C++. See the [pull request](https://github.com/maplibre/maplibre-native/pull/3999) from Meta.

--- a/src/content/roadmap/maplibre-native/plugin-api/index.mdx
+++ b/src/content/roadmap/maplibre-native/plugin-api/index.mdx
@@ -4,7 +4,7 @@ heroImage: "./image.jpg"
 project: maplibre-native
 status: in-progress
 helpWanted: true
-developerLink: https://github.com/maplibre/maplibre-native/pull/3703
+developerLink: https://github.com/maplibre/maplibre-native/discussions/4321
 fundingLink: https://opencollective.com/maplibre/projects/plugin-api-native
 ---
 

--- a/src/content/roadmap/maplibre-native/polygon-corner-radius/index.mdx
+++ b/src/content/roadmap/maplibre-native/polygon-corner-radius/index.mdx
@@ -3,8 +3,9 @@ title: Rounded Edges
 project: maplibre-native
 heroImage: "./image.png"
 status: in-progress
+helpWanted: true
+developerLink: https://github.com/maplibre/maplibre-style-spec/issues/1047
+fundingLink: https://opencollective.com/maplibre/projects/polygon-corner-radius-native
 ---
 
 In January 2026 we started working on allowing styling polygons with rounded edges as well as intersections of roads. The attatched QGIS screenshot gives an impression.
-
-See the [MapLibre Style Spec issue](https://github.com/maplibre/maplibre-style-spec/issues/1047).

--- a/src/content/roadmap/maplibre-native/polygon-corner-radius/index.mdx
+++ b/src/content/roadmap/maplibre-native/polygon-corner-radius/index.mdx
@@ -5,7 +5,6 @@ heroImage: "./image.png"
 status: in-progress
 helpWanted: true
 developerLink: https://github.com/maplibre/maplibre-style-spec/issues/1047
-fundingLink: https://opencollective.com/maplibre/projects/polygon-corner-radius-native
 ---
 
 In January 2026 we started working on allowing styling polygons with rounded edges as well as intersections of roads. The attatched QGIS screenshot gives an impression.

--- a/src/content/roadmap/maplibre-native/polygon-corner-radius/index.mdx
+++ b/src/content/roadmap/maplibre-native/polygon-corner-radius/index.mdx
@@ -3,8 +3,8 @@ title: Rounded Edges
 project: maplibre-native
 heroImage: "./image.png"
 status: in-progress
-helpWanted: true
-developerLink: https://github.com/maplibre/maplibre-style-spec/issues/1047
+links:
+  developer: https://github.com/maplibre/maplibre-style-spec/issues/1047
 ---
 
 In January 2026 we started working on allowing styling polygons with rounded edges as well as intersections of roads. The attatched QGIS screenshot gives an impression.

--- a/src/content/roadmap/maplibre-native/terrain3d/index.mdx
+++ b/src/content/roadmap/maplibre-native/terrain3d/index.mdx
@@ -3,9 +3,9 @@ title: Terrain3D
 heroImage: "./image.png"
 project: maplibre-native
 status: partially-funded
-helpWanted: true
-developerLink: https://github.com/maplibre/maplibre-native/issues/252
-fundingLink: https://opencollective.com/maplibre/projects/terrain3d-native
+links:
+  developer: https://github.com/maplibre/maplibre-native/issues/252
+  funding: https://opencollective.com/maplibre
 ---
 
 Visualization of the elevation from DEM (RGBA tiles) including drawing the tracks, labels and points.

--- a/src/content/roadmap/maplibre-native/terrain3d/index.mdx
+++ b/src/content/roadmap/maplibre-native/terrain3d/index.mdx
@@ -9,4 +9,3 @@ fundingLink: https://opencollective.com/maplibre/projects/terrain3d-native
 ---
 
 Visualization of the elevation from DEM (RGBA tiles) including drawing the tracks, labels and points.
-

--- a/src/content/roadmap/maplibre-native/terrain3d/index.mdx
+++ b/src/content/roadmap/maplibre-native/terrain3d/index.mdx
@@ -3,10 +3,10 @@ title: Terrain3D
 heroImage: "./image.png"
 project: maplibre-native
 status: partially-funded
+helpWanted: true
+developerLink: https://github.com/maplibre/maplibre-native/issues/252
+fundingLink: https://opencollective.com/maplibre/projects/terrain3d-native
 ---
 
 Visualization of the elevation from DEM (RGBA tiles) including drawing the tracks, labels and points.
 
-Issue: https://github.com/maplibre/maplibre-native/issues/252
-
-**Partially funded, please reach out to team@maplibre.org if you are interested in co-sponsoring this feature.**

--- a/src/content/roadmap/martin-tile-server/data-cog/index.mdx
+++ b/src/content/roadmap/martin-tile-server/data-cog/index.mdx
@@ -3,8 +3,8 @@ title: COG Support
 heroImage: "./image.png"
 project: martin-tile-server
 status: in-progress
-helpWanted: true
-developerLink: https://github.com/maplibre/martin/issues/2054
+links:
+  developer: https://github.com/maplibre/martin/issues/2054
 ---
 
 Cloud optimised GeoTIFFs are

--- a/src/content/roadmap/martin-tile-server/data-cog/index.mdx
+++ b/src/content/roadmap/martin-tile-server/data-cog/index.mdx
@@ -3,8 +3,10 @@ title: COG Support
 heroImage: "./image.png"
 project: martin-tile-server
 status: in-progress
+helpWanted: true
+developerLink: https://github.com/maplibre/martin/issues/2054
+fundingLink: https://opencollective.com/maplibre/projects/data-cog-martin
 ---
 
 Cloud optimised GeoTIFFs are
 
-GitHub Issues: [#2054](https://github.com/maplibre/martin/issues/2054)

--- a/src/content/roadmap/martin-tile-server/data-cog/index.mdx
+++ b/src/content/roadmap/martin-tile-server/data-cog/index.mdx
@@ -9,4 +9,3 @@ fundingLink: https://opencollective.com/maplibre/projects/data-cog-martin
 ---
 
 Cloud optimised GeoTIFFs are
-

--- a/src/content/roadmap/martin-tile-server/data-cog/index.mdx
+++ b/src/content/roadmap/martin-tile-server/data-cog/index.mdx
@@ -5,7 +5,6 @@ project: martin-tile-server
 status: in-progress
 helpWanted: true
 developerLink: https://github.com/maplibre/martin/issues/2054
-fundingLink: https://opencollective.com/maplibre/projects/data-cog-martin
 ---
 
 Cloud optimised GeoTIFFs are

--- a/src/content/roadmap/martin-tile-server/data-geojson/index.mdx
+++ b/src/content/roadmap/martin-tile-server/data-geojson/index.mdx
@@ -11,4 +11,3 @@ fundingLink: https://opencollective.com/maplibre/projects/data-geojson-martin
 Dynamic vector tile generation from GeoJSON files and APIs.
 
 This feature is designed as a stepping stone towards supporting other vector tile formats like [GeoParquet](/roadmap/martin-tile-server/data-geoparquet).
-

--- a/src/content/roadmap/martin-tile-server/data-geojson/index.mdx
+++ b/src/content/roadmap/martin-tile-server/data-geojson/index.mdx
@@ -3,8 +3,8 @@ title: GeoJSON Support
 heroImage: "./image.png"
 project: martin-tile-server
 status: in-progress
-helpWanted: true
-developerLink: https://github.com/maplibre/martin/issues/2054
+links:
+  developer: https://github.com/maplibre/martin/issues/2054
 ---
 
 Dynamic vector tile generation from GeoJSON files and APIs.

--- a/src/content/roadmap/martin-tile-server/data-geojson/index.mdx
+++ b/src/content/roadmap/martin-tile-server/data-geojson/index.mdx
@@ -5,7 +5,6 @@ project: martin-tile-server
 status: in-progress
 helpWanted: true
 developerLink: https://github.com/maplibre/martin/issues/2054
-fundingLink: https://opencollective.com/maplibre/projects/data-geojson-martin
 ---
 
 Dynamic vector tile generation from GeoJSON files and APIs.

--- a/src/content/roadmap/martin-tile-server/data-geojson/index.mdx
+++ b/src/content/roadmap/martin-tile-server/data-geojson/index.mdx
@@ -3,10 +3,12 @@ title: GeoJSON Support
 heroImage: "./image.png"
 project: martin-tile-server
 status: in-progress
+helpWanted: true
+developerLink: https://github.com/maplibre/martin/issues/2054
+fundingLink: https://opencollective.com/maplibre/projects/data-geojson-martin
 ---
 
 Dynamic vector tile generation from GeoJSON files and APIs.
 
 This feature is designed as a stepping stone towards supporting other vector tile formats like [GeoParquet](/roadmap/martin-tile-server/data-geoparquet).
 
-GitHub Issues: [#2054](https://github.com/maplibre/martin/issues/2054)

--- a/src/content/roadmap/martin-tile-server/data-geoparquet/index.mdx
+++ b/src/content/roadmap/martin-tile-server/data-geoparquet/index.mdx
@@ -3,8 +3,8 @@ title: GeoParquet Support
 heroImage: "./image.png"
 project: martin-tile-server
 status: under-consideration
-helpWanted: true
-developerLink: https://github.com/maplibre/martin/issues/1693
+links:
+  developer: https://github.com/maplibre/martin/issues/1693
 ---
 
 High-performance vector tile generation from cloud-native GeoParquet datasets.

--- a/src/content/roadmap/martin-tile-server/data-geoparquet/index.mdx
+++ b/src/content/roadmap/martin-tile-server/data-geoparquet/index.mdx
@@ -5,7 +5,6 @@ project: martin-tile-server
 status: under-consideration
 helpWanted: true
 developerLink: https://github.com/maplibre/martin/issues/1693
-fundingLink: https://opencollective.com/maplibre/projects/data-geoparquet-martin
 ---
 
 High-performance vector tile generation from cloud-native GeoParquet datasets.

--- a/src/content/roadmap/martin-tile-server/data-geoparquet/index.mdx
+++ b/src/content/roadmap/martin-tile-server/data-geoparquet/index.mdx
@@ -3,6 +3,9 @@ title: GeoParquet Support
 heroImage: "./image.png"
 project: martin-tile-server
 status: under-consideration
+helpWanted: true
+developerLink: https://github.com/maplibre/martin/issues/1693
+fundingLink: https://opencollective.com/maplibre/projects/data-geoparquet-martin
 ---
 
 High-performance vector tile generation from cloud-native GeoParquet datasets.
@@ -17,7 +20,5 @@ Key features:
 - Memory-efficient streaming for petabyte-scale data
 
 Ideal for Earth observation data, government geodata repositories, and analytics-driven geospatial workflows.
-
-GitHub Issues: [#1693](https://github.com/maplibre/martin/issues/1693)
 
 Specification: [GeoParquet Format](https://geoparquet.org/)

--- a/src/content/roadmap/martin-tile-server/observability/index.mdx
+++ b/src/content/roadmap/martin-tile-server/observability/index.mdx
@@ -4,7 +4,6 @@ heroImage: "./image.png"
 project: martin-tile-server
 status: in-progress
 helpWanted: true
-fundingLink: https://opencollective.com/maplibre/projects/observability-martin
 ---
 
 Comprehensive monitoring and observability stack for production Martin deployments.

--- a/src/content/roadmap/martin-tile-server/observability/index.mdx
+++ b/src/content/roadmap/martin-tile-server/observability/index.mdx
@@ -3,6 +3,8 @@ title: Monitoring & Observability
 heroImage: "./image.png"
 project: martin-tile-server
 status: in-progress
+helpWanted: true
+fundingLink: https://opencollective.com/maplibre/projects/observability-martin
 ---
 
 Comprehensive monitoring and observability stack for production Martin deployments.

--- a/src/content/roadmap/martin-tile-server/observability/index.mdx
+++ b/src/content/roadmap/martin-tile-server/observability/index.mdx
@@ -3,7 +3,6 @@ title: Monitoring & Observability
 heroImage: "./image.png"
 project: martin-tile-server
 status: in-progress
-helpWanted: true
 ---
 
 Comprehensive monitoring and observability stack for production Martin deployments.

--- a/src/content/roadmap/martin-tile-server/style-optimistation/index.mdx
+++ b/src/content/roadmap/martin-tile-server/style-optimistation/index.mdx
@@ -5,7 +5,6 @@ project: martin-tile-server
 status: under-consideration
 helpWanted: true
 developerLink: https://github.com/maplibre/martin/issues/1757
-fundingLink: https://opencollective.com/maplibre/projects/style-optimisation-martin
 ---
 
 Together with the [Techical Unversity of Munichs' chair of Big Geospatial Data Management](https://www.bgd.ed.tum.de/), we are currently working on a thesis where the next generation of vector tile performance from tile servers could come from:

--- a/src/content/roadmap/martin-tile-server/style-optimistation/index.mdx
+++ b/src/content/roadmap/martin-tile-server/style-optimistation/index.mdx
@@ -3,8 +3,8 @@ title: Advanced Style-Data Cooptimization
 heroImage: "./image.png"
 project: martin-tile-server
 status: under-consideration
-helpWanted: true
-developerLink: https://github.com/maplibre/martin/issues/1757
+links:
+  developer: https://github.com/maplibre/martin/issues/1757
 ---
 
 Together with the [Techical Unversity of Munichs' chair of Big Geospatial Data Management](https://www.bgd.ed.tum.de/), we are currently working on a thesis where the next generation of vector tile performance from tile servers could come from:

--- a/src/content/roadmap/martin-tile-server/style-optimistation/index.mdx
+++ b/src/content/roadmap/martin-tile-server/style-optimistation/index.mdx
@@ -3,6 +3,9 @@ title: Advanced Style-Data Cooptimization
 heroImage: "./image.png"
 project: martin-tile-server
 status: under-consideration
+helpWanted: true
+developerLink: https://github.com/maplibre/martin/issues/1757
+fundingLink: https://opencollective.com/maplibre/projects/style-optimisation-martin
 ---
 
 Together with the [Techical Unversity of Munichs' chair of Big Geospatial Data Management](https://www.bgd.ed.tum.de/), we are currently working on a thesis where the next generation of vector tile performance from tile servers could come from:
@@ -31,4 +34,3 @@ Here are the optimisations that are currently planned for evaluation:
 
 List of some possible optimisations. _full scan_ means that this optimisation would require executing one operation over the whole table at minimum. _sampling_ means that this data can be gathered by sampling approaches, but evaluating if a full scan could add context will have to be looked at. For sampling-based approaches, the resampling frequency for the dynamic sources noted in `\cref{access:dynamic}` needs to be determined via statistical approaches. The cases where no scan is necessary does not mean that it might not still be beneficial, for example for parameter tuning.
 
-GitHub Issues: [#1757](https://github.com/maplibre/martin/issues/1757)

--- a/src/content/roadmap/martin-tile-server/style-optimistation/index.mdx
+++ b/src/content/roadmap/martin-tile-server/style-optimistation/index.mdx
@@ -33,4 +33,3 @@ Here are the optimisations that are currently planned for evaluation:
 | static generation             | static source   | extract semantics and generate a new, optimal [static instruction set for constructing the tile database](https://github.com/onthegomap/planetiler/tree/main/planetiler-custommap) |
 
 List of some possible optimisations. _full scan_ means that this optimisation would require executing one operation over the whole table at minimum. _sampling_ means that this data can be gathered by sampling approaches, but evaluating if a full scan could add context will have to be looked at. For sampling-based approaches, the resampling frequency for the dynamic sources noted in `\cref{access:dynamic}` needs to be determined via statistical approaches. The cases where no scan is necessary does not mean that it might not still be beneficial, for example for parameter tuning.
-

--- a/src/content/roadmap/martin-tile-server/style-rendering/index.mdx
+++ b/src/content/roadmap/martin-tile-server/style-rendering/index.mdx
@@ -5,7 +5,6 @@ project: martin-tile-server
 status: in-progress
 helpWanted: true
 developerLink: https://github.com/maplibre/martin/issues/978
-fundingLink: https://opencollective.com/maplibre/projects/style-rendering-martin
 ---
 
 Server-side style rendering capabilities for generating raster tiles and static map images from MapLibre styles.

--- a/src/content/roadmap/martin-tile-server/style-rendering/index.mdx
+++ b/src/content/roadmap/martin-tile-server/style-rendering/index.mdx
@@ -3,6 +3,9 @@ title: Style Rendering
 heroImage: "./image.png"
 project: martin-tile-server
 status: in-progress
+helpWanted: true
+developerLink: https://github.com/maplibre/martin/issues/978
+fundingLink: https://opencollective.com/maplibre/projects/style-rendering-martin
 ---
 
 Server-side style rendering capabilities for generating raster tiles and static map images from MapLibre styles.
@@ -24,7 +27,5 @@ Technical approach:
 - Headless operation for cloud deployment
 - Intelligent caching of rendered output
 - Parallel rendering for performance
-
-GitHub Issues: [#978](https://github.com/maplibre/martin/issues/978)
 
 Documentation: [Style Sources](https://maplibre.org/martin/sources-styles.html)

--- a/src/content/roadmap/martin-tile-server/style-rendering/index.mdx
+++ b/src/content/roadmap/martin-tile-server/style-rendering/index.mdx
@@ -3,8 +3,8 @@ title: Style Rendering
 heroImage: "./image.png"
 project: martin-tile-server
 status: in-progress
-helpWanted: true
-developerLink: https://github.com/maplibre/martin/issues/978
+links:
+  developer: https://github.com/maplibre/martin/issues/978
 ---
 
 Server-side style rendering capabilities for generating raster tiles and static map images from MapLibre styles.

--- a/src/pages/roadmap/[project]/[item].astro
+++ b/src/pages/roadmap/[project]/[item].astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../../../layouts/Layout.astro";
 import TitleHeader from "../../../components/TitleHeader.astro";
+import HelpWanted from "../../../components/HelpWanted.astro";
 import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
 import { render } from "astro:content";
@@ -134,29 +135,12 @@ function formatDate(dateValue) {
 
             <Content />
 
-            {roadmapItem.data.helpWanted ? (
-              <div class="mt-4">
-                <h5>Get Involved</h5>
-                <div class="d-flex gap-3 flex-wrap mt-2">
-                  {roadmapItem.data.developerLink ? (
-                    <a
-                      href={roadmapItem.data.developerLink}
-                      class="btn btn-outline-light"
-                    >
-                      Technical Discussion
-                    </a>
-                  ) : null}
-                  {roadmapItem.data.fundingLink ? (
-                    <a
-                      href={roadmapItem.data.fundingLink}
-                      class="btn btn-primary"
-                    >
-                      Funding
-                    </a>
-                  ) : null}
-                </div>
-              </div>
-            ) : null}
+            {roadmapItem.data.helpWanted && (
+              <HelpWanted
+                developerLink={roadmapItem.data.developerLink}
+                fundingLink={roadmapItem.data.fundingLink}
+              />
+            )}
 
             {roadmapItem.data.released ? (
               <p style="font-weight: bold;">

--- a/src/pages/roadmap/[project]/[item].astro
+++ b/src/pages/roadmap/[project]/[item].astro
@@ -135,10 +135,10 @@ function formatDate(dateValue) {
 
             <Content />
 
-            {roadmapItem.data.helpWanted && (
+            {roadmapItem.data.links && (
               <HelpWanted
-                developerLink={roadmapItem.data.developerLink}
-                fundingLink={roadmapItem.data.fundingLink}
+                developer={roadmapItem.data.links.developer}
+                funding={roadmapItem.data.links.funding}
               />
             )}
 

--- a/src/pages/roadmap/[project]/[item].astro
+++ b/src/pages/roadmap/[project]/[item].astro
@@ -139,12 +139,18 @@ function formatDate(dateValue) {
                 <h5>Get Involved</h5>
                 <div class="d-flex gap-3 flex-wrap mt-2">
                   {roadmapItem.data.developerLink ? (
-                    <a href={roadmapItem.data.developerLink} class="btn btn-outline-light">
+                    <a
+                      href={roadmapItem.data.developerLink}
+                      class="btn btn-outline-light"
+                    >
                       Technical Discussion
                     </a>
                   ) : null}
                   {roadmapItem.data.fundingLink ? (
-                    <a href={roadmapItem.data.fundingLink} class="btn btn-primary">
+                    <a
+                      href={roadmapItem.data.fundingLink}
+                      class="btn btn-primary"
+                    >
                       Funding
                     </a>
                   ) : null}

--- a/src/pages/roadmap/[project]/[item].astro
+++ b/src/pages/roadmap/[project]/[item].astro
@@ -134,6 +134,24 @@ function formatDate(dateValue) {
 
             <Content />
 
+            {roadmapItem.data.helpWanted ? (
+              <div class="mt-4">
+                <h5>Get Involved</h5>
+                <div class="d-flex gap-3 flex-wrap mt-2">
+                  {roadmapItem.data.developerLink ? (
+                    <a href={roadmapItem.data.developerLink} class="btn btn-outline-light">
+                      Technical Discussion
+                    </a>
+                  ) : null}
+                  {roadmapItem.data.fundingLink ? (
+                    <a href={roadmapItem.data.fundingLink} class="btn btn-primary">
+                      Funding
+                    </a>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
+
             {roadmapItem.data.released ? (
               <p style="font-weight: bold;">
                 Released: {formatDate(roadmapItem.data.released)}


### PR DESCRIPTION
Adds a "Get Involved" section to roadmap item detail pages for items that are actively seeking contributions or funding, backed by a structured template so that we can easily point to Open Collective or specific places to drop into the technical discussion.

- Adds `helpWanted`  (boolean) as optional field to the Roadmap content schema with space for additional links: developer (URL), and funding (URL)
-  When `helpWanted: true`, creates a "Get Involved" section on the roadmap item page with optional buttons linking to technical discussion (GitHub) and/or funding pages (OpenCollective)
- Updates the 18 existing roadmap items (across MapLibre GL JS, MapLibre Native, and Martin Tile Server)

## Roadmap Help Wanted Items

Note per earlier discussions with Lauren: what works well for other organizations is to create individual Projects within the MapLibre collective on Open Collective. This allows us to more explicitly address the required budget, business case, use case, or non-technical elements of projects on our Roadmap at a level we are not able to currently.

However, for now, the change only links roadmap items to the main Open Collective page, with suggested slugs for the individual project pages in the table below. 

Note that when creating these pages, we may want to revise or expand the project descriptions on the main MapLibre website as well.

| Project | Title | Status | Description | Technical Discussion | OC Slug |
| --- | --- | --- | --- | --- | --- |
| MapLibre GL JS | Blending Modes | under-consideration | Per-layer/feature blending modes (multiply, add, overlay, etc.) | [discussion/170](https://github.com/maplibre/maplibre/discussions/170) | `/blending-modes` |
| MapLibre GL JS | Graphics Modernization | in-progress | WebGPU rendering backend alongside modernized WebGL2 renderer | [issues/7640](https://github.com/maplibre/maplibre-gl-js/issues/7640) | `/graphics-modernization` |
| MapLibre GL JS | Non-Mercator Projection | under-consideration | Non-Mercator projections and custom coordinate systems/tile matrix sets | [discussion/163](https://github.com/maplibre/maplibre/discussions/163) | `/non-mercator-js` |
| MapLibre GL JS | SVG Symbol Source | under-consideration | Use SVG files as a symbol source | [discussion/175](https://github.com/maplibre/maplibre/discussions/175) | `/svg-symbol-source` |
| MapLibre GL JS | Writing Systems | under-consideration | Support for complex scripts (Myanmar, Thai, etc.) | [pull/4564](https://github.com/maplibre/maplibre-gl-js/pull/4564) | `/writing-systems-js` |
| MapLibre Native | Globe View | partially-funded | Adaptive Composite Map Projection for globe view at low zoom | [issues/3161](https://github.com/maplibre/maplibre-native/issues/3161) | `/globe-view-native` |
| MapLibre Native | Low-Memory Hardening | in-progress | Malloc hardening and graceful degradation under low RAM/GPU memory | ? | `/low-memory-hardening-native` |
| MapLibre Native | Non-Mercator Projection | under-consideration | Non-Mercator projections and custom coordinate systems/tile matrix sets | [discussion/163](https://github.com/maplibre/maplibre/discussions/163) | `/non-mercator-native` |
| MapLibre Native | Plugin API | in-progress | Cross-platform C++ plugin API for extending MapLibre Native | [discussion/4321](https://github.com/maplibre/maplibre-native/discussions/4321) | `/plugin-api-native` |
| MapLibre Native | Rounded Edges | in-progress | Polygons with rounded corners and rounded road intersections | [issues/1047](https://github.com/maplibre/maplibre-style-spec/issues/1047) | No funding needed |
| MapLibre Native | Terrain3D | partially-funded | Elevation visualization from DEM (RGBA) tiles with labels and tracks | [issues/252](https://github.com/maplibre/maplibre-native/issues/252) | `/terrain3d-native` |
| Martin | COG Support | in-progress | Serve raster tiles from Cloud Optimized GeoTIFFs | [issues/2054](https://github.com/maplibre/martin/issues/2054) | No funding needed |
| Martin | GeoJSON Support | in-progress | Dynamic vector tile generation from GeoJSON files and APIs | [issues/2054](https://github.com/maplibre/martin/issues/2054) | No funding needed |
| Martin | GeoParquet Support | under-consideration | High-performance vector tiles from cloud-native GeoParquet datasets | [issues/1693](https://github.com/maplibre/martin/issues/1693) | No funding needed |
| Martin | Monitoring & Observability | in-progress | Prometheus metrics, structured logging, OpenTelemetry tracing, Grafana dashboards | ? | No funding needed |
| Martin | Advanced Style-Data Cooptimization | under-consideration | Co-optimize tile serving with style analysis (dead source elimination, filter reordering, etc.) | [issues/1757](https://github.com/maplibre/martin/issues/1757) | No funding needed |
| Martin | Style Rendering | in-progress | Server-side raster tile and static image generation from MapLibre styles | [issues/978](https://github.com/maplibre/martin/issues/978) | No funding needed |

## Screenshots
| Before | After |
| --- | --- |
|<img width="1019" height="809" alt="Screenshot 2026-06-01 at 8 59 31 AM" src="https://github.com/user-attachments/assets/d691f8ed-8487-44dd-a313-2e62516b8462" /> | <img width="1019" height="824" alt="Screenshot 2026-06-01 at 8 58 57 AM" src="https://github.com/user-attachments/assets/c8402db6-a5dd-4684-884b-cb5a5a6bd2e5" />|



## AI Disclosure

Repetitive restructuring tasks completed by Claude Sonnet 4.6. Claude also helped me write the Astro component logic.

## Follow up

I notice there are several parity items on both the GL JS and Native side that are not on the roadmap. Once this merges we should add them.


## Edit history

2 June 2026 Edited the the implementation description, scope, and table above to reflect discussion below.