### PR TITLE
fix: remove inactive :hover style from news excerpt

### DIFF
--- a/src/pages/about/[...slug].astro
+++ b/src/pages/about/[...slug].astro
@@ -37,7 +37,7 @@ const posts = (
     &:hover {
       background: #111422;
       h3,
-      p:first {
+      p:first-of-type {
         color: white !important;
       }
     }

--- a/src/pages/about/[...slug].astro
+++ b/src/pages/about/[...slug].astro
@@ -36,8 +36,7 @@ const posts = (
 
     &:hover {
       background: #111422;
-      h3,
-      p:first-of-type {
+      h3 {
         color: white !important;
       }
     }

--- a/src/pages/categories/[...slug].astro
+++ b/src/pages/categories/[...slug].astro
@@ -40,7 +40,7 @@ const posts = (
     &:hover {
       background: #111422;
       h3,
-      p:first {
+      p:first-of-type {
         color: white !important;
       }
     }

--- a/src/pages/categories/[...slug].astro
+++ b/src/pages/categories/[...slug].astro
@@ -39,8 +39,7 @@ const posts = (
 
     &:hover {
       background: #111422;
-      h3,
-      p:first-of-type {
+      h3 {
         color: white !important;
       }
     }

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -45,8 +45,7 @@ const blogJsonLd = toJsonLd({
 
     &:hover {
       background: #111422;
-      h3,
-      p:first-of-type {
+      h3 {
         color: white !important;
       }
     }

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -46,7 +46,7 @@ const blogJsonLd = toJsonLd({
     &:hover {
       background: #111422;
       h3,
-      p:first {
+      p:first-of-type {
         color: white !important;
       }
     }


### PR DESCRIPTION
The hover effect of the cards use `p:first` ([MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:first)), which isn't correct and we therefore don't see that style take effect (the excerpt doesn't change color on hover). To make it work, we should be using `:first-of-type` ([MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/:first-of-type)), but it actually looks fine as it is, with only the Header transitioning to white on hover, so this pr removes the no-op selector.