### PR TITLE
fix issue with whitespace due to Astro breaking change

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -30,6 +30,7 @@ export default defineConfig({
       linkCheckerDir: ".link-checker", // Optional: directory for cache and log files (default: '.link-checker')
     }),
   ],
+  compressHTML: true,
   output: "static",
   prefetch: true,
   site: "https://maplibre.org/",


### PR DESCRIPTION
See https://docs.astro.build/en/guides/upgrade-to/v7/#new-default-whitespace-handling-compresshtml-jsx

This used to be the default. The change in Astro is causing problems on our website:

<img width="1400" height="188" alt="image" src="https://github.com/user-attachments/assets/572013bf-2965-4e4b-bc47-1626f2c0dc48" />
